### PR TITLE
feat: Add basic multi world scene support for watchers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ const App = () => {
             {/* Main routes for Cast 2.0 */}
             <Route path="/cast/s/:token" element={<StreamerView />} />
             <Route path="/cast/s/streaming" element={<StreamerView />} />
+            <Route path="/cast/w/:worldName/parcel/:parcel" element={<WatcherView />} />
             <Route path="/cast/w/:location" element={<WatcherView />} />
 
             {/* Root redirects to home/invalid route handler */}

--- a/src/components/ErrorModal/ErrorModal.tsx
+++ b/src/components/ErrorModal/ErrorModal.tsx
@@ -1,7 +1,7 @@
 import { ErrorModalProps } from './ErrorModal.types'
 import { ExitButton, Message, Modal, Overlay, Title } from './ErrorModal.styled'
 
-export function ErrorModal({ title, message, onExit, showExitButton = true }: ErrorModalProps) {
+export function ErrorModal({ title, message, onExit, showExitButton = true, exitButtonText = 'EXIT' }: ErrorModalProps) {
   const handleExit = () => {
     if (onExit) {
       onExit()
@@ -15,7 +15,7 @@ export function ErrorModal({ title, message, onExit, showExitButton = true }: Er
         <Message>{message}</Message>
         {showExitButton && (
           <ExitButton variant="contained" color="error" onClick={handleExit}>
-            EXIT
+            {exitButtonText}
           </ExitButton>
         )}
       </Modal>

--- a/src/components/ErrorModal/ErrorModal.types.ts
+++ b/src/components/ErrorModal/ErrorModal.types.ts
@@ -3,4 +3,5 @@ export interface ErrorModalProps {
   message: string
   onExit?: () => void
   showExitButton?: boolean
+  exitButtonText?: string
 }

--- a/src/components/WatcherView/WatcherView.tsx
+++ b/src/components/WatcherView/WatcherView.tsx
@@ -6,30 +6,75 @@ import { WatcherViewWithChat } from './WatcherViewWithChat'
 import { useLiveKitCredentials } from '../../context/LiveKitContext'
 import { useTranslation } from '../../modules/translation'
 import { LiveKitCredentials } from '../../types'
-import { getWatcherToken } from '../../utils/api'
+import { WorldScene, getWatcherToken, getWorldScenes } from '../../utils/api'
 import { generateRandomName } from '../../utils/identity'
 import { ChatProvider } from '../ChatProvider/ChatProvider'
 import { ViewContainer as WatcherContainer } from '../CommonView/CommonView.styled'
 import { ErrorModal } from '../ErrorModal'
 import { LoadingScreen } from '../LoadingScreen/LoadingScreen'
 import { WatcherOnboarding } from '../WatcherOnboarding/WatcherOnboarding'
+import { WorldSceneSelector } from '../WorldSceneSelector/WorldSceneSelector'
 
 export function WatcherView() {
   const { t } = useTranslation()
-  const { location } = useParams<{ location: string }>()
+  const { location, worldName, parcel: routeParcel } = useParams<{ location?: string; worldName?: string; parcel?: string }>()
   const { setStreamMetadata } = useLiveKitCredentials()
 
+  const isWorldLocation = location?.includes('.dcl.eth')
+  const effectiveWorldName = worldName || (isWorldLocation ? location : undefined)
+  const effectiveLocation = effectiveWorldName?.toLowerCase() || location
+  const isWorld = !!effectiveWorldName
+  const needsSceneSelection = isWorld && !routeParcel
+
+  const [selectedParcel, setSelectedParcel] = useState<string | undefined>(routeParcel)
+  const [sceneSelectionDone, setSceneSelectionDone] = useState(!needsSceneSelection)
+
+  // Scene loading state (only for worlds without a parcel in the URL)
+  const [scenes, setScenes] = useState<WorldScene[]>([])
+  const [isLoadingScenes, setIsLoadingScenes] = useState(needsSceneSelection)
+  const [scenesError, setScenesError] = useState<string | null>(null)
+
+  // Credentials state
   const [credentials, setCredentials] = useState<LiveKitCredentials | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [onboardingComplete, setOnboardingComplete] = useState(false)
   const [isJoining, setIsJoining] = useState(false)
-  const [isLoadingCredentials, setIsLoadingCredentials] = useState(true)
+  const [isLoadingCredentials, setIsLoadingCredentials] = useState(false)
 
-  // Fetch credentials on mount to get room name
+  // Phase 1: Fetch scenes for worlds that need selection
   useEffect(() => {
-    if (!location) {
+    if (!needsSceneSelection || !effectiveWorldName) return
+
+    const fetchScenes = async () => {
+      try {
+        setIsLoadingScenes(true)
+        setScenesError(null)
+        const response = await getWorldScenes(effectiveWorldName)
+        setScenes(response.scenes)
+
+        // Auto-select when there's only one scene
+        if (response.scenes.length === 1) {
+          const scene = response.scenes[0]
+          const baseParcel = scene.entity?.metadata?.scene?.base || scene.parcels[0]
+          setSelectedParcel(baseParcel)
+          setSceneSelectionDone(true)
+        }
+      } catch (err) {
+        setScenesError(err instanceof Error ? err.message : t('watcher.error_connection'))
+      } finally {
+        setIsLoadingScenes(false)
+      }
+    }
+
+    fetchScenes()
+  }, [needsSceneSelection, effectiveWorldName, t])
+
+  // Phase 2: Fetch credentials once scene selection is resolved
+  useEffect(() => {
+    if (!sceneSelectionDone) return
+
+    if (!effectiveLocation) {
       setError('Location is required')
-      setIsLoadingCredentials(false)
       return
     }
 
@@ -38,61 +83,107 @@ export function WatcherView() {
         setIsLoadingCredentials(true)
         setError(null)
 
-        // Generate friendly random identity for watchers
         const identity = generateRandomName()
         console.log('[WatcherView] Using identity:', identity)
-        const liveKitCredentials = await getWatcherToken(location, identity)
+        const liveKitCredentials = await getWatcherToken(effectiveLocation, identity, selectedParcel)
         setCredentials(liveKitCredentials)
 
-        // Set stream metadata for use in ChatPanel
-        const isWorld = location.includes('.dcl.eth')
         setStreamMetadata({
-          placeName: liveKitCredentials.placeName || location,
-          location,
+          placeName: liveKitCredentials.placeName || effectiveLocation,
+          location: effectiveLocation,
           isWorld
         })
-      } catch (error) {
-        setError(error instanceof Error ? error.message : t('watcher.error_connection'))
+      } catch (err) {
+        setError(err instanceof Error ? err.message : t('watcher.error_connection'))
       } finally {
         setIsLoadingCredentials(false)
       }
     }
 
     fetchCredentials()
-  }, [location, t])
+  }, [sceneSelectionDone, effectiveLocation, selectedParcel, isWorld, t, setStreamMetadata])
+
+  const handleSceneSelect = useCallback((parcel: string) => {
+    setSelectedParcel(parcel)
+    setSceneSelectionDone(true)
+  }, [])
+
+  const handleBackToSceneSelector = useCallback(() => {
+    setSelectedParcel(undefined)
+    setSceneSelectionDone(false)
+    setCredentials(null)
+    setError(null)
+  }, [])
 
   const handleJoinRoom = useCallback(() => {
     setIsJoining(true)
-    // Small delay for the spinner animation
     setTimeout(() => {
       setOnboardingComplete(true)
       setIsJoining(false)
     }, 500)
   }, [])
 
-  const handleRoomConnect = useCallback(() => {
-    // Watcher connected to LiveKit room
-  }, [])
+  const handleRoomConnect = useCallback(() => {}, [])
 
   const handleLeaveRoom = useCallback(() => {
     console.log('[WatcherView] Leaving room, returning to onboarding...')
     setOnboardingComplete(false)
   }, [])
 
-  // Loading credentials
+  // Phase 1: Loading scenes
+  if (isLoadingScenes) {
+    return <LoadingScreen message={t('scene_selector.loading')} />
+  }
+
+  // Phase 1: Scene loading error
+  if (scenesError) {
+    return (
+      <ErrorModal
+        title={t('watcher_error_modal.title')}
+        message={scenesError}
+        onExit={() => {
+          window.location.href = 'https://decentraland.org'
+        }}
+      />
+    )
+  }
+
+  // Phase 1: Show scene selector for worlds with multiple scenes
+  if (!sceneSelectionDone) {
+    if (scenes.length === 0) {
+      return (
+        <ErrorModal
+          title={t('watcher_error_modal.title')}
+          message={t('scene_selector.no_scenes')}
+          onExit={() => {
+            window.location.href = 'https://decentraland.org'
+          }}
+        />
+      )
+    }
+    return <WorldSceneSelector scenes={scenes} worldName={effectiveWorldName!} onSelect={handleSceneSelect} />
+  }
+
+  // Phase 2: Loading credentials
   if (isLoadingCredentials) {
     return <LoadingScreen message={t('watcher.connecting')} />
   }
 
   // Show error screen
   if (error) {
+    const canGoBack = needsSceneSelection && scenes.length > 0
     return (
       <ErrorModal
         title={t('watcher_error_modal.title')}
-        message={t('watcher_error_modal.message')}
-        onExit={() => {
-          window.location.href = 'https://decentraland.org'
-        }}
+        message={error}
+        exitButtonText={canGoBack ? t('scene_selector.back') : undefined}
+        onExit={
+          canGoBack
+            ? handleBackToSceneSelector
+            : () => {
+                window.location.href = 'https://decentraland.org'
+              }
+        }
       />
     )
   }
@@ -110,8 +201,7 @@ export function WatcherView() {
     )
   }
 
-  // Extract place name from credentials or use location
-  const streamName = credentials.placeName || credentials.roomName || location || 'Stream'
+  const streamName = credentials.placeName || credentials.roomName || effectiveLocation || 'Stream'
 
   // Show onboarding before connecting
   if (!onboardingComplete) {

--- a/src/components/WorldSceneSelector/WorldSceneSelector.styled.ts
+++ b/src/components/WorldSceneSelector/WorldSceneSelector.styled.ts
@@ -1,0 +1,37 @@
+import { Typography, styled } from 'decentraland-ui2'
+
+const WorldName = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: '#666',
+  textAlign: 'center',
+  marginTop: -theme.spacing(2)
+}))
+
+const SceneSelect = styled('select')(({ theme }) => ({
+  width: '100%',
+  maxWidth: '400px',
+  padding: `${theme.spacing(1.5)} ${theme.spacing(2)}`,
+  borderRadius: theme.spacing(1),
+  border: '1px solid #e0e0e0',
+  backgroundColor: 'white',
+  fontSize: '14px',
+  color: '#1a1a1a',
+  fontFamily: 'inherit',
+  cursor: 'pointer',
+  appearance: 'none',
+  backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23666' d='M6 8L1 3h10z'/%3E%3C/svg%3E")`,
+  backgroundRepeat: 'no-repeat',
+  backgroundPosition: `right ${theme.spacing(2)} center`,
+  paddingRight: theme.spacing(5),
+  transition: 'border-color 0.2s ease',
+  '&:hover': {
+    borderColor: '#999'
+  },
+  '&:focus': {
+    outline: 'none',
+    borderColor: '#FF2D55',
+    boxShadow: '0 0 0 2px rgba(255, 45, 85, 0.1)'
+  }
+}))
+
+export { SceneSelect, WorldName }

--- a/src/components/WorldSceneSelector/WorldSceneSelector.tsx
+++ b/src/components/WorldSceneSelector/WorldSceneSelector.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import logoImage from '../../assets/images/logo.png'
+import { useTranslation } from '../../modules/translation'
+import { WorldScene } from '../../utils/api'
+import {
+  JoinButton,
+  LogoContainer,
+  LogoImage,
+  OnboardingContainer,
+  OnboardingModal,
+  Title
+} from '../WatcherOnboarding/WatcherOnboarding.styled'
+import { WorldSceneSelectorProps } from './WorldSceneSelector.types'
+import { SceneSelect, WorldName } from './WorldSceneSelector.styled'
+
+function getSceneTitle(scene: WorldScene): string {
+  return scene.entity?.metadata?.display?.title || 'Untitled Scene'
+}
+
+function getBaseParcel(scene: WorldScene): string {
+  return scene.entity?.metadata?.scene?.base || scene.parcels[0] || '0,0'
+}
+
+export function WorldSceneSelector({ scenes, worldName, onSelect }: WorldSceneSelectorProps) {
+  const { t } = useTranslation()
+  const [selectedParcel, setSelectedParcel] = useState('')
+
+  const handleConfirm = () => {
+    if (selectedParcel) {
+      onSelect(selectedParcel)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleConfirm()
+    }
+  }
+
+  return (
+    <OnboardingContainer>
+      <OnboardingModal onKeyDown={handleKeyDown}>
+        <LogoContainer>
+          <LogoImage src={logoImage} alt="Decentraland Logo" />
+        </LogoContainer>
+
+        <Title>{t('scene_selector.title')}</Title>
+        <WorldName>{worldName}</WorldName>
+
+        <SceneSelect value={selectedParcel} onChange={e => setSelectedParcel(e.target.value)}>
+          <option value="" disabled>
+            {t('scene_selector.placeholder')}
+          </option>
+          {scenes.map(scene => {
+            const baseParcel = getBaseParcel(scene)
+            const title = getSceneTitle(scene)
+            return (
+              <option key={scene.entityId} value={baseParcel}>
+                {title} ({baseParcel})
+              </option>
+            )
+          })}
+        </SceneSelect>
+
+        <JoinButton onClick={handleConfirm} disabled={!selectedParcel}>
+          {t('scene_selector.watch')}
+        </JoinButton>
+      </OnboardingModal>
+    </OnboardingContainer>
+  )
+}

--- a/src/components/WorldSceneSelector/WorldSceneSelector.types.ts
+++ b/src/components/WorldSceneSelector/WorldSceneSelector.types.ts
@@ -1,0 +1,9 @@
+import { WorldScene } from '../../utils/api'
+
+interface WorldSceneSelectorProps {
+  scenes: WorldScene[]
+  worldName: string
+  onSelect: (parcel: string) => void
+}
+
+export type { WorldSceneSelectorProps }

--- a/src/components/WorldSceneSelector/index.ts
+++ b/src/components/WorldSceneSelector/index.ts
@@ -1,0 +1,1 @@
+export { WorldSceneSelector } from './WorldSceneSelector'

--- a/src/config/env/dev.json
+++ b/src/config/env/dev.json
@@ -1,6 +1,7 @@
 {
   "GATEKEEPER_URL": "https://comms-gatekeeper.decentraland.zone",
   "PEER_URL": "https://peer.decentraland.zone",
+  "WORLDS_CONTENT_URL": "https://worlds-content-server.decentraland.zone",
   "ENVIRONMENT": "development",
   "ANALYTICS_ENABLED": false,
   "DEBUG_MODE": true

--- a/src/config/env/prd.json
+++ b/src/config/env/prd.json
@@ -1,6 +1,7 @@
 {
   "GATEKEEPER_URL": "https://comms-gatekeeper.decentraland.org",
   "PEER_URL": "https://peer.decentraland.org",
+  "WORLDS_CONTENT_URL": "https://worlds-content-server.decentraland.org",
   "ENVIRONMENT": "production",
   "ANALYTICS_ENABLED": true,
   "DEBUG_MODE": false

--- a/src/config/env/stg.json
+++ b/src/config/env/stg.json
@@ -1,6 +1,7 @@
 {
   "GATEKEEPER_URL": "https://comms-gatekeeper.decentraland.zone",
   "PEER_URL": "https://peer-testing.decentraland.org",
+  "WORLDS_CONTENT_URL": "https://worlds-content-server.decentraland.zone",
   "ENVIRONMENT": "staging",
   "ANALYTICS_ENABLED": true,
   "DEBUG_MODE": false

--- a/src/modules/translation/locales/en.json
+++ b/src/modules/translation/locales/en.json
@@ -146,6 +146,14 @@
     "title": "Failed to rejoin cast",
     "message": "Please use the link for this Cast to rejoin."
   },
+  "scene_selector": {
+    "title": "Select a Scene",
+    "placeholder": "Choose a scene to watch",
+    "watch": "WATCH",
+    "back": "BACK",
+    "no_scenes": "No scenes found in this world",
+    "loading": "Loading world scenes..."
+  },
   "watcher_error_modal": {
     "title": "Failed to connect to streaming room",
     "message": "Please use the link sent from the Admin Smart Item to rejoin the streaming."

--- a/src/modules/translation/locales/es.json
+++ b/src/modules/translation/locales/es.json
@@ -146,6 +146,14 @@
     "title": "Error al reingresar al cast",
     "message": "Por favor usa el enlace de este Cast para reingresar."
   },
+  "scene_selector": {
+    "title": "Seleccionar una Escena",
+    "placeholder": "Elige una escena para ver",
+    "watch": "VER",
+    "back": "VOLVER",
+    "no_scenes": "No se encontraron escenas en este mundo",
+    "loading": "Cargando escenas del mundo..."
+  },
   "watcher_error_modal": {
     "title": "Error al conectarse a la sala de transmisión",
     "message": "Por favor usa el enlace enviado desde el Admin Smart Item para reingresar a la transmisión."

--- a/src/modules/translation/locales/zh.json
+++ b/src/modules/translation/locales/zh.json
@@ -146,6 +146,14 @@
     "title": "重新加入Cast失败",
     "message": "请使用此Cast的链接重新加入。"
   },
+  "scene_selector": {
+    "title": "选择场景",
+    "placeholder": "选择要观看的场景",
+    "watch": "观看",
+    "back": "返回",
+    "no_scenes": "此世界中未找到场景",
+    "loading": "加载世界场景中..."
+  },
   "watcher_error_modal": {
     "title": "连接直播室失败",
     "message": "请使用从Admin Smart Item发送的链接重新加入直播。"

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -11,6 +11,34 @@ class CastApiError extends Error {
   }
 }
 
+interface WorldSceneEntity {
+  id: string
+  type: string
+  timestamp: number
+  pointers: string[]
+  metadata?: {
+    display?: {
+      title?: string
+    }
+    scene?: {
+      base?: string
+      parcels?: string[]
+    }
+  }
+}
+
+interface WorldScene {
+  worldName: string
+  entityId: string
+  entity: WorldSceneEntity
+  parcels: string[]
+}
+
+interface WorldScenesResponse {
+  scenes: WorldScene[]
+  total: number
+}
+
 /**
  * Fetches streamer token from gatekeeper
  * @param token - The streaming token
@@ -37,19 +65,47 @@ async function getStreamerToken(token: string, identity: string): Promise<LiveKi
  * Fetches watcher token for viewing
  * @param location - The location (parcel coordinates like "20,-4" or world name like "goerliplaza.dcl.eth")
  * @param identity - The identity/display name for the watcher (required)
+ * @param parcel - The parcel coordinate for world streams (e.g. "1,4")
  */
-async function getWatcherToken(location: string, identity: string): Promise<LiveKitCredentials> {
+async function getWatcherToken(location: string, identity: string, parcel?: string): Promise<LiveKitCredentials> {
   const baseUrl = config.get('GATEKEEPER_URL')
+  const body: Record<string, string> = { location, identity }
+  if (parcel) {
+    body.parcel = parcel
+  }
   const response = await fetch(`${baseUrl}/cast/watcher-token`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ location, identity })
+    body: JSON.stringify(body)
   })
 
   if (!response.ok) {
-    throw new CastApiError(response.status, `Failed to get watcher token: ${response.statusText}`)
+    let errorMessage = 'Unknown error'
+    try {
+      const errorBody = await response.json()
+      if (errorBody.error) {
+        errorMessage = errorBody.error
+      }
+    } catch {
+      // Response wasn't JSON
+    }
+    throw new CastApiError(response.status, errorMessage)
+  }
+
+  return response.json()
+}
+
+/**
+ * Fetches the list of scenes deployed in a world from the worlds content server
+ */
+async function getWorldScenes(worldName: string): Promise<WorldScenesResponse> {
+  const baseUrl = config.get('WORLDS_CONTENT_URL')
+  const response = await fetch(`${baseUrl}/world/${encodeURIComponent(worldName.toLowerCase())}/scenes`)
+
+  if (!response.ok) {
+    throw new CastApiError(response.status, `Failed to get world scenes: ${response.statusText}`)
   }
 
   return response.json()
@@ -72,4 +128,5 @@ async function getStreamInfo(streamingKey: string): Promise<{ placeName: string;
   return response.json()
 }
 
-export { CastApiError, getStreamerToken, getWatcherToken, getStreamInfo }
+export { CastApiError, getStreamerToken, getWatcherToken, getWorldScenes, getStreamInfo }
+export type { WorldScene, WorldSceneEntity, WorldScenesResponse }


### PR DESCRIPTION
Worlds in Decentraland can have multiple scenes, each with its own stream. Until now, the watcher flow assumed a single stream per world — sending only the world name when requesting a watcher token. This PR adds support for multi-scene worlds by introducing a scene selection step and sending the scene's base parcel alongside the world name.

## Why

When a world has more than one scene streaming simultaneously, the gatekeeper needs to know _which_ scene's stream the watcher wants to join. The parcel coordinate (e.g. `"1,4"`) serves as the identifier to disambiguate streams within the same world.

## How

### Scene discovery via the Worlds Content Server

A new `getWorldScenes` API function queries `GET /world/{name}/scenes` on the Worlds Content Server to retrieve all deployed scenes and their parcels. The `WORLDS_CONTENT_URL` config was added to all environment configs to support this.

### Two-phase watcher flow

`WatcherView` now operates in two phases:

1. **Scene resolution** — If the URL is a world name without a parcel (e.g. `/cast/w/goerliplaza.dcl.eth`), scenes are fetched from the content server. If only one scene exists, it is auto-selected. If multiple scenes exist, a `WorldSceneSelector` component is shown — a dropdown listing scenes as "Title (base_parcel)" with a confirm button.
2. **Credential fetch & viewing** — Once a parcel is resolved, `getWatcherToken` is called with the world name (lowercased) and the parcel. The rest of the flow (onboarding, LiveKit connection) proceeds as before.

### Direct parcel route

A new route `/cast/w/:worldName/parcel/:parcel` allows linking directly to a specific scene, bypassing the selector entirely.

<img width="1291" height="1001" alt="Screenshot 2026-02-24 at 4 46 06 PM" src="https://github.com/user-attachments/assets/6341d0b6-2119-4b54-980d-7c3879eadea7" />
