### PR TITLE
feat: add presentation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Cast2
+
 # Decentraland dApp template
 
 ![Decentraland Cover](https://decentraland.org/og.jpg)

--- a/src/components/CommonView/CommonView.styled.ts
+++ b/src/components/CommonView/CommonView.styled.ts
@@ -113,6 +113,8 @@ const Sidebar = styled('div')<{ $isOpen: boolean }>(({ theme, $isOpen }) => {
 })
 
 const ControlsArea = styled('div')({
+  position: 'relative',
+  zIndex: 20,
   width: '100%',
   background: 'transparent',
   flexShrink: 0

--- a/src/components/ParticipantGrid/ParticipantGrid.tsx
+++ b/src/components/ParticipantGrid/ParticipantGrid.tsx
@@ -6,6 +6,7 @@ import { Track } from 'livekit-client'
 import avatarImage from '../../assets/images/avatar.png'
 import { useTranslation } from '../../modules/translation'
 import { getDisplayName } from '../../utils/displayName'
+import { isPresentationBot } from '../../utils/participant'
 import { SpeakingIndicator } from '../LiveKitEnhancements/SpeakingIndicator'
 import { ParticipantGridProps } from './ParticipantGrid.types'
 import {
@@ -198,15 +199,6 @@ function ParticipantGrid({ localParticipantVisible = true }: ParticipantGridProp
   )
 }
 
-function isPresentationBot(participant: TrackReferenceOrPlaceholder['participant']): boolean {
-  try {
-    const metadata = participant.metadata ? JSON.parse(participant.metadata) : null
-    return metadata?.role === 'presentation'
-  } catch {
-    return false
-  }
-}
-
 function ParticipantTile({
   trackRef,
   isFullscreen = false,
@@ -216,6 +208,7 @@ function ParticipantTile({
   isFullscreen?: boolean
   onClick?: () => void
 }) {
+  const { t } = useTranslation()
   const { participant, source, publication } = trackRef
   const isScreenShare = source === Track.Source.ScreenShare
   const isPresentation = isPresentationBot(participant)
@@ -252,8 +245,12 @@ function ParticipantTile({
     return null
   }
 
-  // Get display name: "Presentation" for bot, " - screen" suffix for screen share
-  const displayName = isPresentation ? 'Presentation' : isScreenShare ? `${getDisplayName(participant)} - screen` : getDisplayName(participant)
+  // Get display name: translated "Presentation" for bot, " - screen" suffix for screen share
+  const displayName = isPresentation
+    ? t('streaming_controls.presentation')
+    : isScreenShare
+      ? `${getDisplayName(participant)} - screen`
+      : getDisplayName(participant)
 
   return (
     <ParticipantTileContainer
@@ -266,7 +263,7 @@ function ParticipantTile({
       {isTrackInitializing ? (
         <AvatarFallback>
           <LoadingSpinner />
-          <LoadingText>Initializing video...</LoadingText>
+          <LoadingText>{t('streaming_controls.initializing_video')}</LoadingText>
         </AvatarFallback>
       ) : hasActiveVideo ? (
         <VideoTrack trackRef={trackRef} />

--- a/src/components/ParticipantGrid/ParticipantGrid.tsx
+++ b/src/components/ParticipantGrid/ParticipantGrid.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { TrackReferenceOrPlaceholder, VideoTrack, useIsSpeaking, useTracks } from '@livekit/components-react'
 import MicOffIcon from '@mui/icons-material/MicOff'
 import VideocamOffIcon from '@mui/icons-material/VideocamOff'
@@ -54,22 +54,20 @@ function ParticipantGrid({ localParticipantVisible = true }: ParticipantGridProp
     [filteredTracks]
   )
 
-  // Auto-expand presentation bot tile when it appears, reset when it leaves
+  // Auto-expand presentation bot tile on its first appearance only, so manual
+  // tile selections by the user aren't snapped back to the bot on every rerender.
+  // The ref latches once per bot-presence cycle and resets when the bot leaves.
+  const autoExpandedRef = useRef(false)
   useEffect(() => {
     const presentationTrack = finalTracks.find(t => isPresentationBot(t.participant))
-    if (presentationTrack) {
-      const trackKey = presentationTrack.participant.sid + presentationTrack.source
-      if (expandedTrackSid !== trackKey) {
-        setExpandedTrackSid(trackKey)
-      }
-    } else if (expandedTrackSid) {
-      // If the expanded track no longer exists (bot left), reset to default layout
-      const expandedStillExists = finalTracks.some(t => t.participant.sid + t.source === expandedTrackSid)
-      if (!expandedStillExists) {
-        setExpandedTrackSid(null)
-      }
+    if (presentationTrack && !autoExpandedRef.current) {
+      setExpandedTrackSid(presentationTrack.participant.sid + presentationTrack.source)
+      autoExpandedRef.current = true
+    } else if (!presentationTrack) {
+      autoExpandedRef.current = false
+      setExpandedTrackSid(prev => (prev && !finalTracks.some(t => t.participant.sid + t.source === prev) ? null : prev))
     }
-  }, [finalTracks, expandedTrackSid])
+  }, [finalTracks])
 
   const participantCount = finalTracks.length
   const isFullscreen = participantCount === 1

--- a/src/components/ParticipantGrid/ParticipantGrid.tsx
+++ b/src/components/ParticipantGrid/ParticipantGrid.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { TrackReferenceOrPlaceholder, VideoTrack, useIsSpeaking, useTracks } from '@livekit/components-react'
 import MicOffIcon from '@mui/icons-material/MicOff'
 import VideocamOffIcon from '@mui/icons-material/VideocamOff'
@@ -53,6 +53,23 @@ function ParticipantGrid({ localParticipantVisible = true }: ParticipantGridProp
     [filteredTracks]
   )
 
+  // Auto-expand presentation bot tile when it appears, reset when it leaves
+  useEffect(() => {
+    const presentationTrack = finalTracks.find(t => isPresentationBot(t.participant))
+    if (presentationTrack) {
+      const trackKey = presentationTrack.participant.sid + presentationTrack.source
+      if (expandedTrackSid !== trackKey) {
+        setExpandedTrackSid(trackKey)
+      }
+    } else if (expandedTrackSid) {
+      // If the expanded track no longer exists (bot left), reset to default layout
+      const expandedStillExists = finalTracks.some(t => t.participant.sid + t.source === expandedTrackSid)
+      if (!expandedStillExists) {
+        setExpandedTrackSid(null)
+      }
+    }
+  }, [finalTracks, expandedTrackSid])
+
   const participantCount = finalTracks.length
   const isFullscreen = participantCount === 1
   const hasMultipleParticipants = participantCount >= 2
@@ -100,6 +117,7 @@ function ParticipantGrid({ localParticipantVisible = true }: ParticipantGridProp
   if (hasMultipleParticipants && expandedTrackSid) {
     const expandedTrack = finalTracks.find(t => t.participant.sid + t.source === expandedTrackSid)
     const otherTracks = finalTracks.filter(t => t.participant.sid + t.source !== expandedTrackSid)
+    const isPresentationExpanded = expandedTrack ? isPresentationBot(expandedTrack.participant) : false
 
     // Check if we have more thumbnails than MAX_THUMBNAILS
     // Only show overflow card if there are at least 2 more participants (+2 minimum)
@@ -114,11 +132,11 @@ function ParticipantGrid({ localParticipantVisible = true }: ParticipantGridProp
           <ParticipantTile
             trackRef={expandedTrack}
             isFullscreen={true}
-            onClick={() => handleTileClick(expandedTrack.participant.sid + expandedTrack.source)}
+            onClick={isPresentationExpanded ? undefined : () => handleTileClick(expandedTrack.participant.sid + expandedTrack.source)}
           />
         )}
-        {/* Show other tracks in vertical thumbnail grid */}
-        {otherTracks.length === 1 ? (
+        {/* Hide participant thumbnails during presentation — slides are the focus */}
+        {isPresentationExpanded ? null : otherTracks.length === 1 ? (
           // Single floating video
           <FloatingVideoContainer>
             <ParticipantTile
@@ -180,6 +198,15 @@ function ParticipantGrid({ localParticipantVisible = true }: ParticipantGridProp
   )
 }
 
+function isPresentationBot(participant: TrackReferenceOrPlaceholder['participant']): boolean {
+  try {
+    const metadata = participant.metadata ? JSON.parse(participant.metadata) : null
+    return metadata?.role === 'presentation'
+  } catch {
+    return false
+  }
+}
+
 function ParticipantTile({
   trackRef,
   isFullscreen = false,
@@ -191,9 +218,10 @@ function ParticipantTile({
 }) {
   const { participant, source, publication } = trackRef
   const isScreenShare = source === Track.Source.ScreenShare
+  const isPresentation = isPresentationBot(participant)
 
-  // Only apply speaking indicator to camera, not screen share
-  const isSpeaking = useIsSpeaking(participant) && !isScreenShare
+  // Only apply speaking indicator to camera, not screen share or presentation bot
+  const isSpeaking = useIsSpeaking(participant) && !isScreenShare && !isPresentation
 
   // Get audio track for speaking indicator and muted state
   const audioTrackRefs = useTracks([Track.Source.Microphone], {
@@ -224,8 +252,8 @@ function ParticipantTile({
     return null
   }
 
-  // Get display name with " - screen" suffix for screen share
-  const displayName = isScreenShare ? `${getDisplayName(participant)} - screen` : getDisplayName(participant)
+  // Get display name: "Presentation" for bot, " - screen" suffix for screen share
+  const displayName = isPresentation ? 'Presentation' : isScreenShare ? `${getDisplayName(participant)} - screen` : getDisplayName(participant)
 
   return (
     <ParticipantTileContainer
@@ -248,13 +276,13 @@ function ParticipantTile({
         </AvatarFallback>
       )}
 
-      {!isScreenShare && (
+      {!isScreenShare && !isPresentation && (
         <SpeakingIndicatorWrapper>
           <SpeakingIndicator participant={participant} trackRef={participantAudioTrack} />
         </SpeakingIndicatorWrapper>
       )}
 
-      {isMuted && !isScreenShare && (
+      {isMuted && !isScreenShare && !isPresentation && (
         <MutedIndicator>
           <MicOffIcon />
         </MutedIndicator>

--- a/src/components/PresentationControls/PresentationControls.styled.ts
+++ b/src/components/PresentationControls/PresentationControls.styled.ts
@@ -96,3 +96,46 @@ export const UploadingOverlay = styled('div')({
   color: 'white',
   fontSize: 14
 })
+
+export const ErrorOverlay = styled('div')(({ theme }) => ({
+  position: 'absolute',
+  bottom: 16,
+  left: '50%',
+  transform: 'translateX(-50%)',
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+  padding: '10px 16px 10px 20px',
+  background: theme.palette.primary.main,
+  borderRadius: 20,
+  color: 'white',
+  fontSize: 14,
+  maxWidth: 'calc(100vw - 32px)'
+}))
+
+export const ErrorMessage = styled('span')({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap'
+})
+
+export const ErrorDismissButton = styled('button')({
+  width: 24,
+  height: 24,
+  borderRadius: '50%',
+  background: 'rgba(255, 255, 255, 0.2)',
+  border: 'none',
+  color: 'white',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'pointer',
+  flexShrink: 0,
+  transition: 'background 0.2s ease',
+  '&:hover': {
+    background: 'rgba(255, 255, 255, 0.35)'
+  },
+  '& svg': {
+    fontSize: 16
+  }
+})

--- a/src/components/PresentationControls/PresentationControls.styled.ts
+++ b/src/components/PresentationControls/PresentationControls.styled.ts
@@ -1,0 +1,98 @@
+import { styled } from 'decentraland-ui2'
+
+export const PresentationControlsOverlay = styled('div')({
+  position: 'absolute',
+  bottom: 16,
+  left: '50%',
+  transform: 'translateX(-50%)',
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4
+})
+
+export const NavButton = styled('button')({
+  width: 36,
+  height: 36,
+  borderRadius: '50%',
+  background: 'rgba(0, 0, 0, 0.6)',
+  backdropFilter: 'blur(10px)',
+  border: 'none',
+  color: 'white',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'pointer',
+  transition: 'background 0.2s ease',
+  '&:hover': {
+    background: 'rgba(0, 0, 0, 0.8)'
+  },
+  '&:disabled': {
+    opacity: 0.3,
+    cursor: 'default'
+  },
+  '& svg': {
+    fontSize: 22
+  }
+})
+
+export const SlideInfo = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '6px 16px',
+  background: 'rgba(0, 0, 0, 0.6)',
+  backdropFilter: 'blur(10px)',
+  borderRadius: 20,
+  color: 'white',
+  fontSize: 13,
+  fontWeight: 500,
+  userSelect: 'none'
+})
+
+export const VideoButton = styled('button')({
+  width: 36,
+  height: 36,
+  borderRadius: '50%',
+  background: 'rgba(0, 0, 0, 0.6)',
+  backdropFilter: 'blur(10px)',
+  border: 'none',
+  color: 'white',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'pointer',
+  transition: 'background 0.2s ease',
+  '&:hover': {
+    background: 'rgba(0, 0, 0, 0.8)'
+  },
+  '&:disabled': {
+    opacity: 0.6,
+    cursor: 'wait'
+  },
+  '& svg': {
+    fontSize: 20
+  }
+})
+
+export const Divider = styled('div')({
+  width: 1,
+  height: 24,
+  background: 'rgba(255, 255, 255, 0.3)',
+  margin: '0 4px'
+})
+
+export const UploadingOverlay = styled('div')({
+  position: 'absolute',
+  bottom: 16,
+  left: '50%',
+  transform: 'translateX(-50%)',
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '8px 20px',
+  background: 'rgba(0, 0, 0, 0.75)',
+  backdropFilter: 'blur(10px)',
+  borderRadius: 20,
+  color: 'white',
+  fontSize: 14
+})

--- a/src/components/PresentationControls/PresentationControls.tsx
+++ b/src/components/PresentationControls/PresentationControls.tsx
@@ -83,11 +83,7 @@ export function PresentationControls() {
       </NavButton>
 
       <Divider style={{ visibility: hasVideos ? 'visible' : 'hidden' }} />
-      <VideoButton
-        onClick={handleToggleVideo}
-        disabled={isVideoLoading}
-        style={{ visibility: hasVideos ? 'visible' : 'hidden' }}
-      >
+      <VideoButton onClick={handleToggleVideo} disabled={isVideoLoading} style={{ visibility: hasVideos ? 'visible' : 'hidden' }}>
         {isVideoLoading ? <HourglassEmptyIcon /> : isVideoPlaying ? <PauseIcon /> : <PlayArrowIcon />}
       </VideoButton>
       <VideoButton

--- a/src/components/PresentationControls/PresentationControls.tsx
+++ b/src/components/PresentationControls/PresentationControls.tsx
@@ -1,0 +1,89 @@
+import { useCallback, useEffect } from 'react'
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty'
+import PauseIcon from '@mui/icons-material/Pause'
+import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import { usePresentation } from '../../context/PresentationContext'
+import { Divider, NavButton, PresentationControlsOverlay, SlideInfo, UploadingOverlay, VideoButton } from './PresentationControls.styled'
+
+export function PresentationControls() {
+  const { state, navigateSlide, playVideo, pauseVideo } = usePresentation()
+
+  const isActive = state.status === 'active'
+  const isFirstSlide = state.currentSlide === 0
+  const isLastSlide = state.currentSlide === state.slideCount - 1
+  const hasVideos = state.slideVideos.length > 0
+  const isVideoPlaying = state.videoState === 'playing'
+  const isVideoLoading = state.videoState === 'loading'
+
+  const handleToggleVideo = useCallback(() => {
+    if (isVideoLoading) return
+    if (isVideoPlaying) {
+      pauseVideo()
+    } else {
+      playVideo(0)
+    }
+  }, [isVideoLoading, isVideoPlaying, pauseVideo, playVideo])
+
+  // Keyboard shortcuts: arrows for navigation, space for video play/pause
+  useEffect(() => {
+    if (!isActive) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Don't capture if user is typing in an input
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+
+      switch (e.key) {
+        case 'ArrowLeft':
+          e.preventDefault()
+          if (!isFirstSlide) navigateSlide('prev')
+          break
+        case 'ArrowRight':
+          e.preventDefault()
+          if (!isLastSlide) navigateSlide('next')
+          break
+        case ' ':
+          e.preventDefault()
+          if (hasVideos) handleToggleVideo()
+          break
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isActive, isFirstSlide, isLastSlide, hasVideos, navigateSlide, handleToggleVideo])
+
+  if (state.status === 'uploading') {
+    return <UploadingOverlay>Uploading presentation...</UploadingOverlay>
+  }
+
+  if (!isActive) {
+    return null
+  }
+
+  return (
+    <PresentationControlsOverlay>
+      <NavButton onClick={() => navigateSlide('prev')} disabled={isFirstSlide}>
+        <ChevronLeftIcon />
+      </NavButton>
+
+      <SlideInfo>
+        {state.currentSlide + 1} / {state.slideCount}
+      </SlideInfo>
+
+      <NavButton onClick={() => navigateSlide('next')} disabled={isLastSlide}>
+        <ChevronRightIcon />
+      </NavButton>
+
+      <Divider style={{ visibility: hasVideos ? 'visible' : 'hidden' }} />
+      <VideoButton
+        onClick={handleToggleVideo}
+        disabled={isVideoLoading}
+        style={{ visibility: hasVideos ? 'visible' : 'hidden' }}
+      >
+        {isVideoLoading ? <HourglassEmptyIcon /> : isVideoPlaying ? <PauseIcon /> : <PlayArrowIcon />}
+      </VideoButton>
+    </PresentationControlsOverlay>
+  )
+}

--- a/src/components/PresentationControls/PresentationControls.tsx
+++ b/src/components/PresentationControls/PresentationControls.tsx
@@ -6,9 +6,11 @@ import PauseIcon from '@mui/icons-material/Pause'
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
 import StopIcon from '@mui/icons-material/Stop'
 import { usePresentation } from '../../context/PresentationContext'
+import { useTranslation } from '../../modules/translation'
 import { Divider, NavButton, PresentationControlsOverlay, SlideInfo, UploadingOverlay, VideoButton } from './PresentationControls.styled'
 
 export function PresentationControls() {
+  const { t } = useTranslation()
   const { state, navigateSlide, playVideo, pauseVideo, stopVideo } = usePresentation()
 
   const isActive = state.status === 'active'
@@ -61,7 +63,7 @@ export function PresentationControls() {
   }, [isActive, isFirstSlide, isLastSlide, hasVideos, navigateSlide, handleToggleVideo])
 
   if (state.status === 'uploading') {
-    return <UploadingOverlay>Uploading presentation...</UploadingOverlay>
+    return <UploadingOverlay>{t('streaming_controls.uploading_presentation')}</UploadingOverlay>
   }
 
   if (!isActive) {

--- a/src/components/PresentationControls/PresentationControls.tsx
+++ b/src/components/PresentationControls/PresentationControls.tsx
@@ -1,17 +1,28 @@
 import { useCallback, useEffect } from 'react'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import CloseIcon from '@mui/icons-material/Close'
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty'
 import PauseIcon from '@mui/icons-material/Pause'
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
 import StopIcon from '@mui/icons-material/Stop'
 import { usePresentation } from '../../context/PresentationContext'
 import { useTranslation } from '../../modules/translation'
-import { Divider, NavButton, PresentationControlsOverlay, SlideInfo, UploadingOverlay, VideoButton } from './PresentationControls.styled'
+import {
+  Divider,
+  ErrorDismissButton,
+  ErrorMessage,
+  ErrorOverlay,
+  NavButton,
+  PresentationControlsOverlay,
+  SlideInfo,
+  UploadingOverlay,
+  VideoButton
+} from './PresentationControls.styled'
 
 export function PresentationControls() {
   const { t } = useTranslation()
-  const { state, navigateSlide, playVideo, pauseVideo, stopVideo } = usePresentation()
+  const { state, navigateSlide, playVideo, pauseVideo, stopVideo, dismissError } = usePresentation()
 
   const isActive = state.status === 'active'
   const isFirstSlide = state.currentSlide === 0
@@ -66,6 +77,17 @@ export function PresentationControls() {
   // joining the room — keep the overlay up so the UI doesn't go blank.
   if (state.status === 'uploading' || state.status === 'starting') {
     return <UploadingOverlay>{t('streaming_controls.uploading_presentation')}</UploadingOverlay>
+  }
+
+  if (state.status === 'error') {
+    return (
+      <ErrorOverlay>
+        <ErrorMessage title={state.error ?? undefined}>{state.error ?? t('streaming_controls.presentation_error_default')}</ErrorMessage>
+        <ErrorDismissButton onClick={dismissError} aria-label={t('streaming_controls.dismiss_error')}>
+          <CloseIcon />
+        </ErrorDismissButton>
+      </ErrorOverlay>
+    )
   }
 
   if (!isActive) {

--- a/src/components/PresentationControls/PresentationControls.tsx
+++ b/src/components/PresentationControls/PresentationControls.tsx
@@ -62,7 +62,9 @@ export function PresentationControls() {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [isActive, isFirstSlide, isLastSlide, hasVideos, navigateSlide, handleToggleVideo])
 
-  if (state.status === 'uploading') {
+  // 'starting' is the brief window between upload completion and the bot
+  // joining the room — keep the overlay up so the UI doesn't go blank.
+  if (state.status === 'uploading' || state.status === 'starting') {
     return <UploadingOverlay>{t('streaming_controls.uploading_presentation')}</UploadingOverlay>
   }
 

--- a/src/components/PresentationControls/PresentationControls.tsx
+++ b/src/components/PresentationControls/PresentationControls.tsx
@@ -4,11 +4,12 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty'
 import PauseIcon from '@mui/icons-material/Pause'
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import StopIcon from '@mui/icons-material/Stop'
 import { usePresentation } from '../../context/PresentationContext'
 import { Divider, NavButton, PresentationControlsOverlay, SlideInfo, UploadingOverlay, VideoButton } from './PresentationControls.styled'
 
 export function PresentationControls() {
-  const { state, navigateSlide, playVideo, pauseVideo } = usePresentation()
+  const { state, navigateSlide, playVideo, pauseVideo, stopVideo } = usePresentation()
 
   const isActive = state.status === 'active'
   const isFirstSlide = state.currentSlide === 0
@@ -25,6 +26,11 @@ export function PresentationControls() {
       playVideo(0)
     }
   }, [isVideoLoading, isVideoPlaying, pauseVideo, playVideo])
+
+  const handleStopVideo = useCallback(() => {
+    if (isVideoLoading) return
+    stopVideo()
+  }, [isVideoLoading, stopVideo])
 
   // Keyboard shortcuts: arrows for navigation, space for video play/pause
   useEffect(() => {
@@ -83,6 +89,13 @@ export function PresentationControls() {
         style={{ visibility: hasVideos ? 'visible' : 'hidden' }}
       >
         {isVideoLoading ? <HourglassEmptyIcon /> : isVideoPlaying ? <PauseIcon /> : <PlayArrowIcon />}
+      </VideoButton>
+      <VideoButton
+        onClick={handleStopVideo}
+        disabled={isVideoLoading || state.videoState === 'idle'}
+        style={{ visibility: hasVideos ? 'visible' : 'hidden' }}
+      >
+        <StopIcon />
       </VideoButton>
     </PresentationControlsOverlay>
   )

--- a/src/components/SharePresentationModal/SharePresentationModal.styled.ts
+++ b/src/components/SharePresentationModal/SharePresentationModal.styled.ts
@@ -1,0 +1,119 @@
+import { Button, styled } from 'decentraland-ui2'
+
+export const Overlay = styled('div')({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  background: 'rgba(0, 0, 0, 0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 9999
+})
+
+export const Modal = styled('div')(({ theme }) => ({
+  backgroundColor: 'white',
+  borderRadius: 12,
+  padding: '32px 40px',
+  width: 480,
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 20,
+  [theme.breakpoints.down('sm')]: {
+    width: 'calc(100% - 32px)',
+    padding: '24px 20px'
+  }
+}))
+
+export const CloseButton = styled('button')({
+  position: 'absolute',
+  top: 16,
+  right: 16,
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  color: '#666',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 4,
+  '&:hover': {
+    color: '#333'
+  },
+  '& svg': {
+    fontSize: 24
+  }
+})
+
+export const Title = styled('h2')({
+  margin: 0,
+  fontSize: 20,
+  fontWeight: 600,
+  color: '#16141a'
+})
+
+export const UrlRow = styled('div')({
+  display: 'flex',
+  width: '100%',
+  gap: 8,
+  alignItems: 'center'
+})
+
+export const UrlInput = styled('input')({
+  flex: 1,
+  padding: '10px 14px',
+  border: '1px solid #ccc',
+  borderRadius: 6,
+  fontSize: 14,
+  outline: 'none',
+  color: '#16141a',
+  '&::placeholder': {
+    color: '#999'
+  },
+  '&:focus': {
+    borderColor: '#ff2d55'
+  }
+})
+
+export const ShareButton = styled(Button)({
+  background: '#ff2d55',
+  color: 'white',
+  fontWeight: 600,
+  fontSize: 14,
+  textTransform: 'uppercase',
+  padding: '10px 20px',
+  minWidth: 'unset',
+  borderRadius: 6,
+  '&:hover': {
+    background: '#e0264b'
+  }
+})
+
+export const Divider = styled('div')({
+  color: '#999',
+  fontSize: 14,
+  textAlign: 'center'
+})
+
+export const BrowseButton = styled(Button)({
+  background: '#ff2d55',
+  color: 'white',
+  fontWeight: 600,
+  fontSize: 14,
+  textTransform: 'uppercase',
+  padding: '10px 24px',
+  borderRadius: 6,
+  '&:hover': {
+    background: '#e0264b'
+  }
+})
+
+export const SupportedFormats = styled('div')({
+  color: '#999',
+  fontSize: 12,
+  textAlign: 'center'
+})

--- a/src/components/SharePresentationModal/SharePresentationModal.styled.ts
+++ b/src/components/SharePresentationModal/SharePresentationModal.styled.ts
@@ -63,7 +63,7 @@ const UrlRow = styled('div')({
   alignItems: 'center'
 })
 
-const UrlInput = styled('input')({
+const UrlInput = styled('input')(({ theme }) => ({
   flex: 1,
   padding: '10px 14px',
   border: '1px solid #ccc',
@@ -75,12 +75,12 @@ const UrlInput = styled('input')({
     color: '#999'
   },
   '&:focus': {
-    borderColor: '#ff2d55'
+    borderColor: theme.palette.primary.main
   }
-})
+}))
 
-const ShareButton = styled(Button)({
-  background: '#ff2d55',
+const ShareButton = styled(Button)(({ theme }) => ({
+  background: theme.palette.primary.main,
   color: 'white',
   fontWeight: 600,
   fontSize: 14,
@@ -89,9 +89,9 @@ const ShareButton = styled(Button)({
   minWidth: 'unset',
   borderRadius: 6,
   '&:hover': {
-    background: '#e0264b'
+    background: theme.palette.primary.dark
   }
-})
+}))
 
 const Divider = styled('div')({
   color: '#999',
@@ -99,8 +99,8 @@ const Divider = styled('div')({
   textAlign: 'center'
 })
 
-const BrowseButton = styled(Button)({
-  background: '#ff2d55',
+const BrowseButton = styled(Button)(({ theme }) => ({
+  background: theme.palette.primary.main,
   color: 'white',
   fontWeight: 600,
   fontSize: 14,
@@ -108,9 +108,9 @@ const BrowseButton = styled(Button)({
   padding: '10px 24px',
   borderRadius: 6,
   '&:hover': {
-    background: '#e0264b'
+    background: theme.palette.primary.dark
   }
-})
+}))
 
 const SupportedFormats = styled('div')({
   color: '#999',
@@ -118,12 +118,12 @@ const SupportedFormats = styled('div')({
   textAlign: 'center'
 })
 
-const ErrorText = styled('div')({
-  color: '#ff2d55',
+const ErrorText = styled('div')(({ theme }) => ({
+  color: theme.palette.primary.main,
   fontSize: 12,
   width: '100%',
   textAlign: 'left',
   marginTop: -12
-})
+}))
 
 export { Overlay, Modal, CloseButton, Title, UrlRow, UrlInput, ShareButton, Divider, BrowseButton, SupportedFormats, ErrorText }

--- a/src/components/SharePresentationModal/SharePresentationModal.styled.ts
+++ b/src/components/SharePresentationModal/SharePresentationModal.styled.ts
@@ -1,6 +1,6 @@
 import { Button, styled } from 'decentraland-ui2'
 
-export const Overlay = styled('div')({
+const Overlay = styled('div')({
   position: 'fixed',
   top: 0,
   left: 0,
@@ -13,7 +13,7 @@ export const Overlay = styled('div')({
   zIndex: 9999
 })
 
-export const Modal = styled('div')(({ theme }) => ({
+const Modal = styled('div')(({ theme }) => ({
   backgroundColor: 'white',
   borderRadius: 12,
   padding: '32px 40px',
@@ -29,7 +29,7 @@ export const Modal = styled('div')(({ theme }) => ({
   }
 }))
 
-export const CloseButton = styled('button')({
+const CloseButton = styled('button')({
   position: 'absolute',
   top: 16,
   right: 16,
@@ -49,21 +49,21 @@ export const CloseButton = styled('button')({
   }
 })
 
-export const Title = styled('h2')({
+const Title = styled('h2')({
   margin: 0,
   fontSize: 20,
   fontWeight: 600,
   color: '#16141a'
 })
 
-export const UrlRow = styled('div')({
+const UrlRow = styled('div')({
   display: 'flex',
   width: '100%',
   gap: 8,
   alignItems: 'center'
 })
 
-export const UrlInput = styled('input')({
+const UrlInput = styled('input')({
   flex: 1,
   padding: '10px 14px',
   border: '1px solid #ccc',
@@ -79,7 +79,7 @@ export const UrlInput = styled('input')({
   }
 })
 
-export const ShareButton = styled(Button)({
+const ShareButton = styled(Button)({
   background: '#ff2d55',
   color: 'white',
   fontWeight: 600,
@@ -93,13 +93,13 @@ export const ShareButton = styled(Button)({
   }
 })
 
-export const Divider = styled('div')({
+const Divider = styled('div')({
   color: '#999',
   fontSize: 14,
   textAlign: 'center'
 })
 
-export const BrowseButton = styled(Button)({
+const BrowseButton = styled(Button)({
   background: '#ff2d55',
   color: 'white',
   fontWeight: 600,
@@ -112,8 +112,18 @@ export const BrowseButton = styled(Button)({
   }
 })
 
-export const SupportedFormats = styled('div')({
+const SupportedFormats = styled('div')({
   color: '#999',
   fontSize: 12,
   textAlign: 'center'
 })
+
+const ErrorText = styled('div')({
+  color: '#ff2d55',
+  fontSize: 12,
+  width: '100%',
+  textAlign: 'left',
+  marginTop: -12
+})
+
+export { Overlay, Modal, CloseButton, Title, UrlRow, UrlInput, ShareButton, Divider, BrowseButton, SupportedFormats, ErrorText }

--- a/src/components/SharePresentationModal/SharePresentationModal.tsx
+++ b/src/components/SharePresentationModal/SharePresentationModal.tsx
@@ -77,9 +77,9 @@ export function SharePresentationModal({ onClose, onFileSelected, onUrlSubmitted
         <Divider>or</Divider>
 
         <BrowseButton onClick={handleBrowse}>Browse your local files</BrowseButton>
-        <input ref={fileInputRef} type="file" accept=".pdf" style={{ display: 'none' }} onChange={handleFileChange} />
+        <input ref={fileInputRef} type="file" accept=".pdf,.pptx" style={{ display: 'none' }} onChange={handleFileChange} />
 
-        <SupportedFormats>Supported format: PDF.</SupportedFormats>
+        <SupportedFormats>Supported formats: PDF, PPTX.</SupportedFormats>
       </Modal>
     </Overlay>
   )

--- a/src/components/SharePresentationModal/SharePresentationModal.tsx
+++ b/src/components/SharePresentationModal/SharePresentationModal.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import CloseIcon from '@mui/icons-material/Close'
 import {
   BrowseButton,
@@ -6,17 +6,22 @@ import {
   Divider,
   Modal,
   Overlay,
+  ShareButton,
   SupportedFormats,
-  Title
+  Title,
+  UrlInput,
+  UrlRow
 } from './SharePresentationModal.styled'
 
 interface SharePresentationModalProps {
   onClose: () => void
   onFileSelected: (file: File) => void
+  onUrlSubmitted: (url: string) => void
 }
 
-export function SharePresentationModal({ onClose, onFileSelected }: SharePresentationModalProps) {
+export function SharePresentationModal({ onClose, onFileSelected, onUrlSubmitted }: SharePresentationModalProps) {
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const [url, setUrl] = useState('')
 
   const handleBrowse = () => {
     fileInputRef.current?.click()
@@ -29,6 +34,19 @@ export function SharePresentationModal({ onClose, onFileSelected }: SharePresent
       onClose()
     }
     event.target.value = ''
+  }
+
+  const handleShareUrl = () => {
+    const trimmed = url.trim()
+    if (!trimmed) return
+    onUrlSubmitted(trimmed)
+    onClose()
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleShareUrl()
+    }
   }
 
   const handleOverlayClick = (event: React.MouseEvent) => {
@@ -46,12 +64,22 @@ export function SharePresentationModal({ onClose, onFileSelected }: SharePresent
 
         <Title>Share Presentation</Title>
 
-        <Divider>Browse a file from your computer</Divider>
+        <UrlRow>
+          <UrlInput
+            placeholder="Paste your presentation URL"
+            value={url}
+            onChange={e => setUrl(e.target.value)}
+            onKeyDown={handleKeyDown}
+          />
+          <ShareButton onClick={handleShareUrl} disabled={!url.trim()}>Share</ShareButton>
+        </UrlRow>
+
+        <Divider>or</Divider>
 
         <BrowseButton onClick={handleBrowse}>Browse your local files</BrowseButton>
-        <input ref={fileInputRef} type="file" accept=".pdf" style={{ display: 'none' }} onChange={handleFileChange} />
+        <input ref={fileInputRef} type="file" accept=".pdf,.pptx" style={{ display: 'none' }} onChange={handleFileChange} />
 
-        <SupportedFormats>Supported formats: PDF</SupportedFormats>
+        <SupportedFormats>Supported formats: gslides (Google Slides) and PDF.</SupportedFormats>
       </Modal>
     </Overlay>
   )

--- a/src/components/SharePresentationModal/SharePresentationModal.tsx
+++ b/src/components/SharePresentationModal/SharePresentationModal.tsx
@@ -1,9 +1,11 @@
 import { useRef, useState } from 'react'
 import CloseIcon from '@mui/icons-material/Close'
+import { useTranslation } from '../../modules/translation'
 import {
   BrowseButton,
   CloseButton,
   Divider,
+  ErrorText,
   Modal,
   Overlay,
   ShareButton,
@@ -20,8 +22,10 @@ interface SharePresentationModalProps {
 }
 
 export function SharePresentationModal({ onClose, onFileSelected, onUrlSubmitted }: SharePresentationModalProps) {
+  const { t } = useTranslation()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [url, setUrl] = useState('')
+  const [urlError, setUrlError] = useState<string | null>(null)
 
   const handleBrowse = () => {
     fileInputRef.current?.click()
@@ -39,8 +43,25 @@ export function SharePresentationModal({ onClose, onFileSelected, onUrlSubmitted
   const handleShareUrl = () => {
     const trimmed = url.trim()
     if (!trimmed) return
+    let parsed: URL
+    try {
+      parsed = new URL(trimmed)
+    } catch {
+      setUrlError(t('streaming_controls.url_invalid'))
+      return
+    }
+    if (parsed.protocol !== 'https:') {
+      setUrlError(t('streaming_controls.url_https_required'))
+      return
+    }
+    setUrlError(null)
     onUrlSubmitted(trimmed)
     onClose()
+  }
+
+  const handleUrlChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setUrl(event.target.value)
+    if (urlError) setUrlError(null)
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -62,24 +83,28 @@ export function SharePresentationModal({ onClose, onFileSelected, onUrlSubmitted
           <CloseIcon />
         </CloseButton>
 
-        <Title>Share Presentation</Title>
+        <Title>{t('streaming_controls.share_presentation')}</Title>
 
         <UrlRow>
           <UrlInput
-            placeholder="Paste your presentation URL"
+            placeholder={t('streaming_controls.paste_presentation_url')}
             value={url}
-            onChange={e => setUrl(e.target.value)}
+            onChange={handleUrlChange}
             onKeyDown={handleKeyDown}
           />
-          <ShareButton onClick={handleShareUrl} disabled={!url.trim()}>Share</ShareButton>
+          <ShareButton onClick={handleShareUrl} disabled={!url.trim()}>
+            {t('streaming_controls.share')}
+          </ShareButton>
         </UrlRow>
 
-        <Divider>or</Divider>
+        {urlError && <ErrorText>{urlError}</ErrorText>}
 
-        <BrowseButton onClick={handleBrowse}>Browse your local files</BrowseButton>
+        <Divider>{t('streaming_controls.or')}</Divider>
+
+        <BrowseButton onClick={handleBrowse}>{t('streaming_controls.browse_local_files')}</BrowseButton>
         <input ref={fileInputRef} type="file" accept=".pdf,.pptx" style={{ display: 'none' }} onChange={handleFileChange} />
 
-        <SupportedFormats>Supported formats: PDF, PPTX.</SupportedFormats>
+        <SupportedFormats>{t('streaming_controls.supported_formats')}</SupportedFormats>
       </Modal>
     </Overlay>
   )

--- a/src/components/SharePresentationModal/SharePresentationModal.tsx
+++ b/src/components/SharePresentationModal/SharePresentationModal.tsx
@@ -24,6 +24,12 @@ interface SharePresentationModalProps {
 const MAX_FILE_SIZE_MB = 100
 const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024
 
+// Accept by extension *and* MIME (when the browser provides one). Some browsers
+// return an empty `file.type` for .pptx, so extension alone must be sufficient,
+// but a mismatched non-empty MIME is always rejected to block renamed files.
+const VALID_EXT_REGEX = /\.(pdf|pptx)$/i
+const ALLOWED_MIME_TYPES = new Set(['application/pdf', 'application/vnd.openxmlformats-officedocument.presentationml.presentation'])
+
 export function SharePresentationModal({ onClose, onFileSelected, onUrlSubmitted }: SharePresentationModalProps) {
   const { t } = useTranslation()
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -41,6 +47,10 @@ export function SharePresentationModal({ onClose, onFileSelected, onUrlSubmitted
     if (!file) return
     if (file.size > MAX_FILE_SIZE_BYTES) {
       setFileError(t('streaming_controls.file_too_large', { maxMb: String(MAX_FILE_SIZE_MB) }))
+      return
+    }
+    if (!VALID_EXT_REGEX.test(file.name) || (file.type && !ALLOWED_MIME_TYPES.has(file.type))) {
+      setFileError(t('streaming_controls.file_invalid_type'))
       return
     }
     setFileError(null)

--- a/src/components/SharePresentationModal/SharePresentationModal.tsx
+++ b/src/components/SharePresentationModal/SharePresentationModal.tsx
@@ -77,9 +77,9 @@ export function SharePresentationModal({ onClose, onFileSelected, onUrlSubmitted
         <Divider>or</Divider>
 
         <BrowseButton onClick={handleBrowse}>Browse your local files</BrowseButton>
-        <input ref={fileInputRef} type="file" accept=".pdf,.pptx" style={{ display: 'none' }} onChange={handleFileChange} />
+        <input ref={fileInputRef} type="file" accept=".pdf" style={{ display: 'none' }} onChange={handleFileChange} />
 
-        <SupportedFormats>Supported formats: gslides (Google Slides) and PDF.</SupportedFormats>
+        <SupportedFormats>Supported format: PDF.</SupportedFormats>
       </Modal>
     </Overlay>
   )

--- a/src/components/SharePresentationModal/SharePresentationModal.tsx
+++ b/src/components/SharePresentationModal/SharePresentationModal.tsx
@@ -1,0 +1,58 @@
+import { useRef } from 'react'
+import CloseIcon from '@mui/icons-material/Close'
+import {
+  BrowseButton,
+  CloseButton,
+  Divider,
+  Modal,
+  Overlay,
+  SupportedFormats,
+  Title
+} from './SharePresentationModal.styled'
+
+interface SharePresentationModalProps {
+  onClose: () => void
+  onFileSelected: (file: File) => void
+}
+
+export function SharePresentationModal({ onClose, onFileSelected }: SharePresentationModalProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleBrowse = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (file) {
+      onFileSelected(file)
+      onClose()
+    }
+    event.target.value = ''
+  }
+
+  const handleOverlayClick = (event: React.MouseEvent) => {
+    if (event.target === event.currentTarget) {
+      onClose()
+    }
+  }
+
+  return (
+    <Overlay onClick={handleOverlayClick}>
+      <Modal>
+        <CloseButton onClick={onClose}>
+          <CloseIcon />
+        </CloseButton>
+
+        <Title>Share Presentation</Title>
+
+        <Divider>Browse a file from your computer</Divider>
+
+        <BrowseButton onClick={handleBrowse}>Browse your local files</BrowseButton>
+        <input ref={fileInputRef} type="file" accept=".pdf" style={{ display: 'none' }} onChange={handleFileChange} />
+
+        <SupportedFormats>Supported formats: PDF</SupportedFormats>
+      </Modal>
+    </Overlay>
+  )
+}

--- a/src/components/SharePresentationModal/SharePresentationModal.tsx
+++ b/src/components/SharePresentationModal/SharePresentationModal.tsx
@@ -21,11 +21,15 @@ interface SharePresentationModalProps {
   onUrlSubmitted: (url: string) => void
 }
 
+const MAX_FILE_SIZE_MB = 100
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024
+
 export function SharePresentationModal({ onClose, onFileSelected, onUrlSubmitted }: SharePresentationModalProps) {
   const { t } = useTranslation()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [url, setUrl] = useState('')
   const [urlError, setUrlError] = useState<string | null>(null)
+  const [fileError, setFileError] = useState<string | null>(null)
 
   const handleBrowse = () => {
     fileInputRef.current?.click()
@@ -33,11 +37,15 @@ export function SharePresentationModal({ onClose, onFileSelected, onUrlSubmitted
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
-    if (file) {
-      onFileSelected(file)
-      onClose()
-    }
     event.target.value = ''
+    if (!file) return
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      setFileError(t('streaming_controls.file_too_large', { maxMb: String(MAX_FILE_SIZE_MB) }))
+      return
+    }
+    setFileError(null)
+    onFileSelected(file)
+    onClose()
   }
 
   const handleShareUrl = () => {
@@ -103,6 +111,8 @@ export function SharePresentationModal({ onClose, onFileSelected, onUrlSubmitted
 
         <BrowseButton onClick={handleBrowse}>{t('streaming_controls.browse_local_files')}</BrowseButton>
         <input ref={fileInputRef} type="file" accept=".pdf,.pptx" style={{ display: 'none' }} onChange={handleFileChange} />
+
+        {fileError && <ErrorText>{fileError}</ErrorText>}
 
         <SupportedFormats>{t('streaming_controls.supported_formats')}</SupportedFormats>
       </Modal>

--- a/src/components/StreamerView/StreamerView.tsx
+++ b/src/components/StreamerView/StreamerView.tsx
@@ -27,6 +27,7 @@ export function StreamerView() {
   const [activeToken, setActiveToken] = useState<string | null>(null)
   const [placeName, setPlaceName] = useState<string | null>(null)
   const [loadingPlaceInfo, setLoadingPlaceInfo] = useState(false)
+  const [isTabMuted, setIsTabMuted] = useState(false)
 
   // Determine which token to use and handle URL cleanup
   const determineToken = useCallback(() => {
@@ -163,10 +164,10 @@ export function StreamerView() {
         screen={false}
       >
         <ChatProvider>
-          <StreamerViewWithChat onLeave={handleLeaveRoom} />
+          <StreamerViewWithChat onLeave={handleLeaveRoom} isTabMuted={isTabMuted} onToggleTabMute={() => setIsTabMuted(prev => !prev)} />
         </ChatProvider>
 
-        <RoomAudioRenderer />
+        <RoomAudioRenderer volume={isTabMuted ? 0 : 1} />
         <ConnectionStateToast />
       </LiveKitRoom>
     </StreamerContainer>

--- a/src/components/StreamerView/StreamerViewWithChat.tsx
+++ b/src/components/StreamerView/StreamerViewWithChat.tsx
@@ -17,9 +17,11 @@ import { StreamingControls } from '../StreamingControls/StreamingControls'
 
 interface StreamerViewWithChatProps {
   onLeave: () => void
+  isTabMuted: boolean
+  onToggleTabMute: () => void
 }
 
-export function StreamerViewWithChat({ onLeave }: StreamerViewWithChatProps) {
+export function StreamerViewWithChat({ onLeave, isTabMuted, onToggleTabMute }: StreamerViewWithChatProps) {
   const [peopleOpen, setPeopleOpen] = useState(false)
   const { chatMessages, unreadMessagesCount, markMessagesAsRead, isChatOpen, setChatOpen } = useChatContext()
 
@@ -58,6 +60,8 @@ export function StreamerViewWithChat({ onLeave }: StreamerViewWithChatProps) {
               isStreamer
               onLeave={onLeave}
               unreadMessagesCount={unreadMessagesCount}
+              isTabMuted={isTabMuted}
+              onToggleTabMute={onToggleTabMute}
             />
           </ControlsArea>
         </MainContent>

--- a/src/components/StreamerView/StreamerViewWithChat.tsx
+++ b/src/components/StreamerView/StreamerViewWithChat.tsx
@@ -11,6 +11,8 @@ import {
   VideoContainer
 } from '../CommonView/CommonView.styled'
 import { PeopleSidebar } from '../PeopleSidebar/PeopleSidebar'
+import { PresentationProvider } from '../../context/PresentationContext'
+import { PresentationControls } from '../PresentationControls/PresentationControls'
 import { StreamingControls } from '../StreamingControls/StreamingControls'
 
 interface StreamerViewWithChatProps {
@@ -34,29 +36,32 @@ export function StreamerViewWithChat({ onLeave }: StreamerViewWithChatProps) {
   }, [isChatOpen, peopleOpen, setChatOpen])
 
   return (
-    <StreamerLayout>
-      <MainContent>
-        <VideoContainer $sidebarOpen={sidebarOpen}>
-          <VideoArea $sidebarOpen={sidebarOpen}>
-            <StreamerViewContent />
-          </VideoArea>
+    <PresentationProvider>
+      <StreamerLayout>
+        <MainContent>
+          <VideoContainer $sidebarOpen={sidebarOpen}>
+            <VideoArea $sidebarOpen={sidebarOpen}>
+              <StreamerViewContent />
+              <PresentationControls />
+            </VideoArea>
 
-          <Sidebar $isOpen={sidebarOpen}>
-            {isChatOpen && <ChatPanel onClose={handleToggleChat} chatMessages={chatMessages} onMessagesRead={markMessagesAsRead} />}
-            {peopleOpen && <PeopleSidebar onClose={handleTogglePeople} />}
-          </Sidebar>
-        </VideoContainer>
+            <Sidebar $isOpen={sidebarOpen}>
+              {isChatOpen && <ChatPanel onClose={handleToggleChat} chatMessages={chatMessages} onMessagesRead={markMessagesAsRead} />}
+              {peopleOpen && <PeopleSidebar onClose={handleTogglePeople} />}
+            </Sidebar>
+          </VideoContainer>
 
-        <ControlsArea>
-          <StreamingControls
-            onToggleChat={handleToggleChat}
-            onTogglePeople={handleTogglePeople}
-            isStreamer
-            onLeave={onLeave}
-            unreadMessagesCount={unreadMessagesCount}
-          />
-        </ControlsArea>
-      </MainContent>
-    </StreamerLayout>
+          <ControlsArea>
+            <StreamingControls
+              onToggleChat={handleToggleChat}
+              onTogglePeople={handleTogglePeople}
+              isStreamer
+              onLeave={onLeave}
+              unreadMessagesCount={unreadMessagesCount}
+            />
+          </ControlsArea>
+        </MainContent>
+      </StreamerLayout>
+    </PresentationProvider>
   )
 }

--- a/src/components/StreamingControls/ShareMenuDropdown.tsx
+++ b/src/components/StreamingControls/ShareMenuDropdown.tsx
@@ -1,0 +1,42 @@
+import ScreenShareIcon from '@mui/icons-material/ScreenShare'
+import SlideshowIcon from '@mui/icons-material/Slideshow'
+import StopIcon from '@mui/icons-material/Stop'
+import { useTranslation } from '../../modules/translation'
+import { ShareMenu, ShareMenuItem } from './StreamingControls.styled'
+
+interface ShareMenuDropdownProps {
+  isPresentationActive: boolean
+  onShareScreen: () => void
+  onSharePresentation: () => void
+  onStopPresentation: () => void
+}
+
+export function ShareMenuDropdown({
+  isPresentationActive,
+  onShareScreen,
+  onSharePresentation,
+  onStopPresentation
+}: ShareMenuDropdownProps) {
+  const { t } = useTranslation()
+  return (
+    <ShareMenu data-dropdown-menu>
+      {isPresentationActive ? (
+        <ShareMenuItem onClick={onStopPresentation}>
+          <StopIcon />
+          {t('streaming_controls.stop_presentation')}
+        </ShareMenuItem>
+      ) : (
+        <>
+          <ShareMenuItem onClick={onShareScreen}>
+            <ScreenShareIcon />
+            {t('streaming_controls.share_screen')}
+          </ShareMenuItem>
+          <ShareMenuItem onClick={onSharePresentation}>
+            <SlideshowIcon />
+            {t('streaming_controls.share_presentation')}
+          </ShareMenuItem>
+        </>
+      )}
+    </ShareMenu>
+  )
+}

--- a/src/components/StreamingControls/StreamingControls.styled.ts
+++ b/src/components/StreamingControls/StreamingControls.styled.ts
@@ -296,6 +296,40 @@ const CircleEndButton = styled('button')(({ theme }) => ({
   }
 }))
 
+const ShareMenuItem = styled('div')({
+  padding: '10px 16px',
+  color: '#16141a',
+  cursor: 'pointer',
+  fontSize: 14,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 10,
+  transition: 'background 0.15s ease',
+  whiteSpace: 'nowrap',
+  '&:hover': {
+    background: 'rgba(0, 0, 0, 0.05)'
+  },
+  '& svg': {
+    fontSize: 20,
+    color: '#666'
+  }
+})
+
+const ShareMenu = styled('div')({
+  position: 'absolute',
+  bottom: '100%',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  marginBottom: 8,
+  background: 'white',
+  borderRadius: 8,
+  border: '1px solid rgba(0, 0, 0, 0.1)',
+  boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+  padding: '4px 0',
+  minWidth: 200,
+  zIndex: 1
+})
+
 export {
   ButtonWithMenu,
   ChevronButton,
@@ -313,5 +347,7 @@ export {
   MobileIconButton,
   MobileLeftGroup,
   MobileRightGroup,
-  NotificationBadge
+  NotificationBadge,
+  ShareMenu,
+  ShareMenuItem
 }

--- a/src/components/StreamingControls/StreamingControls.test.tsx
+++ b/src/components/StreamingControls/StreamingControls.test.tsx
@@ -221,6 +221,40 @@ describe('StreamingControls', () => {
     })
   })
 
+  describe('mute tab audio button', () => {
+    it('should render volume button when onToggleTabMute is provided', () => {
+      renderWithProviders(<StreamingControls isStreamer={true} onToggleTabMute={jest.fn()} />)
+
+      const volumeIcons = screen.getAllByTestId('VolumeUpIcon')
+      expect(volumeIcons.length).toBeGreaterThan(0)
+    })
+
+    it('should show VolumeOffIcon when tab is muted', () => {
+      renderWithProviders(<StreamingControls isStreamer={true} isTabMuted={true} onToggleTabMute={jest.fn()} />)
+
+      const volumeOffIcons = screen.getAllByTestId('VolumeOffIcon')
+      expect(volumeOffIcons.length).toBeGreaterThan(0)
+      expect(screen.queryByTestId('VolumeUpIcon')).not.toBeInTheDocument()
+    })
+
+    it('should call onToggleTabMute when clicked', () => {
+      const mockOnToggleTabMute = jest.fn()
+      renderWithProviders(<StreamingControls isStreamer={true} onToggleTabMute={mockOnToggleTabMute} />)
+
+      const volumeButton = screen.getAllByTestId('VolumeUpIcon')[0].closest('button')
+      fireEvent.click(volumeButton!)
+
+      expect(mockOnToggleTabMute).toHaveBeenCalled()
+    })
+
+    it('should not render volume button when onToggleTabMute is not provided', () => {
+      renderWithProviders(<StreamingControls isStreamer={true} />)
+
+      expect(screen.queryByTestId('VolumeUpIcon')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('VolumeOffIcon')).not.toBeInTheDocument()
+    })
+  })
+
   describe('when disconnected', () => {
     beforeEach(() => {
       mockUseConnectionState.mockReturnValue(ConnectionState.Disconnected)

--- a/src/components/StreamingControls/StreamingControls.test.tsx
+++ b/src/components/StreamingControls/StreamingControls.test.tsx
@@ -133,13 +133,16 @@ describe('StreamingControls', () => {
     })
 
     describe('and the screen share button is clicked', () => {
-      it('should enable screen sharing', async () => {
+      it('should enable screen sharing via share menu', async () => {
         renderWithProviders(<StreamingControls isStreamer={true} onToggleChat={mockOnToggleChat} onTogglePeople={mockOnTogglePeople} />)
 
-        // Find screen share button by ScreenShareIcon (use getAllByTestId as there are desktop and mobile versions)
-        const screenShareButton = screen.getAllByTestId('ScreenShareIcon')[0].closest('button')
+        // Click the share button to open the dropdown menu
+        const shareButton = screen.getAllByTestId('ScreenShareIcon')[0].closest('button')
+        fireEvent.click(shareButton!)
 
-        fireEvent.click(screenShareButton!)
+        // Click "Share Screen" from the dropdown menu (multiple due to mobile/desktop)
+        const shareScreenOption = screen.getAllByText('Share Screen')[0]
+        fireEvent.click(shareScreenOption)
 
         await waitFor(() => {
           expect(mockSetScreenShareEnabled).toHaveBeenCalledWith(true, { audio: true })

--- a/src/components/StreamingControls/StreamingControls.tsx
+++ b/src/components/StreamingControls/StreamingControls.tsx
@@ -96,6 +96,11 @@ export function StreamingControls({
     await presentationContext.startPresentation(file)
   }
 
+  const handlePresentationUrlSubmitted = async (url: string) => {
+    if (!presentationContext) return
+    await presentationContext.startPresentationFromUrl(url)
+  }
+
   const { enabled: isMicEnabled } = useTrackToggle({
     source: Track.Source.Microphone
   })
@@ -623,6 +628,7 @@ export function StreamingControls({
       <SharePresentationModal
         onClose={() => setShowPresentationModal(false)}
         onFileSelected={handlePresentationFileSelected}
+        onUrlSubmitted={handlePresentationUrlSubmitted}
       />
     )}
     </>

--- a/src/components/StreamingControls/StreamingControls.tsx
+++ b/src/components/StreamingControls/StreamingControls.tsx
@@ -7,12 +7,16 @@ import MicIcon from '@mui/icons-material/Mic'
 import MicOffIcon from '@mui/icons-material/MicOff'
 import PeopleIcon from '@mui/icons-material/People'
 import ScreenShareIcon from '@mui/icons-material/ScreenShare'
+import SlideshowIcon from '@mui/icons-material/Slideshow'
+import StopIcon from '@mui/icons-material/Stop'
 import StopScreenShareIcon from '@mui/icons-material/StopScreenShare'
 import VideocamIcon from '@mui/icons-material/Videocam'
 import VideocamOffIcon from '@mui/icons-material/VideocamOff'
 import { ConnectionState, LocalAudioTrack, LocalVideoTrack, Track } from 'livekit-client'
 import { useLiveKitCredentials } from '../../context/LiveKitContext'
+import { usePresentationOptional } from '../../context/PresentationContext'
 import { useTranslation } from '../../modules/translation'
+import { SharePresentationModal } from '../SharePresentationModal/SharePresentationModal'
 import { StreamingControlsProps } from './StreamingControls.types'
 import {
   ButtonWithMenu,
@@ -31,7 +35,9 @@ import {
   MobileIconButton,
   MobileLeftGroup,
   MobileRightGroup,
-  NotificationBadge
+  NotificationBadge,
+  ShareMenu,
+  ShareMenuItem
 } from './StreamingControls.styled'
 
 export function StreamingControls({
@@ -45,7 +51,6 @@ export function StreamingControls({
   const room = useRoomContext()
   const { localParticipant } = useLocalParticipant()
   const remoteParticipants = useRemoteParticipants()
-  console.log('remoteParticipants', remoteParticipants)
   const connectionState = useConnectionState()
   const [isScreenSharing, setIsScreenSharing] = useState(false)
   const [showAudioMenu, setShowAudioMenu] = useState(false)
@@ -54,6 +59,42 @@ export function StreamingControls({
   const [videoDevices, setVideoDevices] = useState<MediaDeviceInfo[]>([])
   const [selectedAudioDevice, setSelectedAudioDevice] = useState<string>('')
   const [selectedVideoDevice, setSelectedVideoDevice] = useState<string>('')
+  const [showShareMenu, setShowShareMenu] = useState(false)
+  const [showPresentationModal, setShowPresentationModal] = useState(false)
+
+  const presentationContext = usePresentationOptional()
+  const isPresentationActive = presentationContext?.isPresentationActive ?? false
+  const isSharingAnything = isScreenSharing || isPresentationActive
+
+  const handleShareScreenClick = () => {
+    setShowShareMenu(false)
+    handleScreenShare()
+  }
+
+  const handleSharePresentationClick = () => {
+    setShowShareMenu(false)
+    setShowPresentationModal(true)
+  }
+
+  const handleStopPresentation = () => {
+    setShowShareMenu(false)
+    presentationContext?.stopPresentation()
+  }
+
+  const handleShareButtonClick = () => {
+    if (isScreenSharing) {
+      handleScreenShare() // stops screen share
+    } else if (isPresentationActive) {
+      setShowShareMenu(!showShareMenu)
+    } else {
+      setShowShareMenu(!showShareMenu)
+    }
+  }
+
+  const handlePresentationFileSelected = async (file: File) => {
+    if (!presentationContext) return
+    await presentationContext.startPresentation(file)
+  }
 
   const { enabled: isMicEnabled } = useTrackToggle({
     source: Track.Source.Microphone
@@ -115,6 +156,7 @@ export function StreamingControls({
       if (!target.closest('[data-dropdown-menu]') && !target.closest('[data-dropdown-button]')) {
         setShowAudioMenu(false)
         setShowVideoMenu(false)
+        setShowShareMenu(false)
       }
     }
 
@@ -331,6 +373,7 @@ export function StreamingControls({
   }
 
   return (
+    <>
     <ControlsContainer>
       {/* Mobile Left Controls: Media controls (visible only on mobile) */}
       <ControlsLeft>
@@ -384,9 +427,39 @@ export function StreamingControls({
           </ButtonWithMenu>
         )}
 
-        {/* Screen Share - Only for streamer */}
+        {/* Share (Screen / Presentation) - Only for streamer */}
         {isStreamer && (
-          <CircleButton onClick={handleScreenShare}>{isScreenSharing ? <StopScreenShareIcon /> : <ScreenShareIcon />}</CircleButton>
+          <ButtonWithMenu>
+            <CircleButton onClick={handleShareButtonClick} data-dropdown-button>
+              {isPresentationActive ? <SlideshowIcon /> : isScreenSharing ? <StopScreenShareIcon /> : <ScreenShareIcon />}
+            </CircleButton>
+            {!isScreenSharing && (
+              <ChevronButton data-dropdown-button onClick={() => setShowShareMenu(!showShareMenu)}>
+                <ExpandMoreIcon />
+              </ChevronButton>
+            )}
+            {showShareMenu && (
+              <ShareMenu data-dropdown-menu>
+                {isPresentationActive ? (
+                  <ShareMenuItem onClick={handleStopPresentation}>
+                    <StopIcon />
+                    Stop Presentation
+                  </ShareMenuItem>
+                ) : (
+                  <>
+                    <ShareMenuItem onClick={handleShareScreenClick}>
+                      <ScreenShareIcon />
+                      Share Screen
+                    </ShareMenuItem>
+                    <ShareMenuItem onClick={handleSharePresentationClick}>
+                      <SlideshowIcon />
+                      Share Presentation
+                    </ShareMenuItem>
+                  </>
+                )}
+              </ShareMenu>
+            )}
+          </ButtonWithMenu>
         )}
       </ControlsLeft>
 
@@ -439,7 +512,38 @@ export function StreamingControls({
               )}
             </ButtonWithMenu>
 
-            <CircleButton onClick={handleScreenShare}>{isScreenSharing ? <StopScreenShareIcon /> : <ScreenShareIcon />}</CircleButton>
+            {/* Share (Screen / Presentation) dropdown */}
+            <ButtonWithMenu>
+              <CircleButton onClick={handleShareButtonClick} data-dropdown-button>
+                {isPresentationActive ? <SlideshowIcon /> : isScreenSharing ? <StopScreenShareIcon /> : <ScreenShareIcon />}
+              </CircleButton>
+              {!isScreenSharing && (
+                <ChevronButton data-dropdown-button onClick={() => setShowShareMenu(!showShareMenu)}>
+                  <ExpandMoreIcon />
+                </ChevronButton>
+              )}
+              {showShareMenu && (
+                <ShareMenu data-dropdown-menu>
+                  {isPresentationActive ? (
+                    <ShareMenuItem onClick={handleStopPresentation}>
+                      <StopIcon />
+                      Stop Presentation
+                    </ShareMenuItem>
+                  ) : (
+                    <>
+                      <ShareMenuItem onClick={handleShareScreenClick}>
+                        <ScreenShareIcon />
+                        Share Screen
+                      </ShareMenuItem>
+                      <ShareMenuItem onClick={handleSharePresentationClick}>
+                        <SlideshowIcon />
+                        Share Presentation
+                      </ShareMenuItem>
+                    </>
+                  )}
+                </ShareMenu>
+              )}
+            </ButtonWithMenu>
 
             {/* Leave/Hang-up button - Desktop only, positioned after media controls */}
             {isDisconnected ? (
@@ -514,5 +618,13 @@ export function StreamingControls({
         </MobileRightGroup>
       </ControlsRight>
     </ControlsContainer>
+
+    {showPresentationModal && (
+      <SharePresentationModal
+        onClose={() => setShowPresentationModal(false)}
+        onFileSelected={handlePresentationFileSelected}
+      />
+    )}
+    </>
   )
 }

--- a/src/components/StreamingControls/StreamingControls.tsx
+++ b/src/components/StreamingControls/StreamingControls.tsx
@@ -111,21 +111,9 @@ export function StreamingControls({
   const getDevices = useCallback(async () => {
     try {
       const devices = await navigator.mediaDevices.enumerateDevices()
-      console.log('[StreamingControls] Found devices:', devices)
       // Keep ALL devices including "default" - let the user choose their system default
       const audioInputs = devices.filter(d => d.kind === 'audioinput')
       const videoInputs = devices.filter(d => d.kind === 'videoinput')
-
-      console.log(
-        '[StreamingControls] Found audio devices:',
-        audioInputs.length,
-        audioInputs.map(d => d.label)
-      )
-      console.log(
-        '[StreamingControls] Found video devices:',
-        videoInputs.length,
-        videoInputs.map(d => d.label)
-      )
 
       setAudioDevices(audioInputs)
       setVideoDevices(videoInputs)
@@ -133,12 +121,10 @@ export function StreamingControls({
       // Auto-select "default" device or first available if none selected
       if (!selectedAudioDevice && audioInputs.length > 0) {
         const defaultDevice = audioInputs.find(d => d.deviceId === 'default') || audioInputs[0]
-        console.log('[StreamingControls] Auto-selecting audio device:', defaultDevice.deviceId, defaultDevice.label)
         setSelectedAudioDevice(defaultDevice.deviceId)
       }
       if (!selectedVideoDevice && videoInputs.length > 0) {
         const defaultDevice = videoInputs.find(d => d.deviceId === 'default') || videoInputs[0]
-        console.log('[StreamingControls] Auto-selecting video device:', defaultDevice.deviceId, defaultDevice.label)
         setSelectedVideoDevice(defaultDevice.deviceId)
       }
     } catch (error) {
@@ -177,7 +163,6 @@ export function StreamingControls({
     // Listen for screen share track ending (e.g., when user stops from Chrome controls)
     if (screenShareTrack?.track) {
       const handleTrackEnded = () => {
-        console.log('[StreamingControls] Screen share track ended (stopped by browser)')
         setIsScreenSharing(false)
       }
 
@@ -195,10 +180,8 @@ export function StreamingControls({
 
     try {
       if (isMicEnabled) {
-        console.log('[StreamingControls] Disabling microphone')
         await localParticipant.setMicrophoneEnabled(false)
       } else {
-        console.log('[StreamingControls] Enabling microphone with device:', selectedAudioDevice)
         // Use "exact" constraint to force the specific device
         await localParticipant.setMicrophoneEnabled(true, selectedAudioDevice ? { deviceId: { exact: selectedAudioDevice } } : undefined)
       }
@@ -212,10 +195,8 @@ export function StreamingControls({
 
     try {
       if (isCameraEnabled) {
-        console.log('[StreamingControls] Disabling camera')
         await localParticipant.setCameraEnabled(false)
       } else {
-        console.log('[StreamingControls] Enabling camera with device:', selectedVideoDevice)
         // Use "exact" constraint to force the specific device
         await localParticipant.setCameraEnabled(true, selectedVideoDevice ? { deviceId: { exact: selectedVideoDevice } } : undefined)
       }
@@ -230,22 +211,13 @@ export function StreamingControls({
       return
     }
 
-    console.log('[StreamingControls] Screen share toggle requested', {
-      currentState: isScreenSharing,
-      isMobile: /iPhone|iPad|iPod|Android/i.test(navigator.userAgent),
-      userAgent: navigator.userAgent,
-      hasGetDisplayMedia: !!(navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia)
-    })
-
     if (isScreenSharing) {
-      console.log('[StreamingControls] Stopping screen share')
       const screenShareTrack = Array.from(localParticipant.videoTrackPublications.values()).find(
         pub => pub.source === Track.Source.ScreenShare
       )
       if (screenShareTrack) {
         await localParticipant.unpublishTrack(screenShareTrack.track!)
         setIsScreenSharing(false)
-        console.log('[StreamingControls] Screen share stopped successfully')
       }
     } else {
       try {
@@ -263,23 +235,15 @@ export function StreamingControls({
           return
         }
 
-        console.log('[StreamingControls] Starting screen share')
         await localParticipant.setScreenShareEnabled(true, { audio: true })
         setIsScreenSharing(true)
-        console.log('[StreamingControls] Screen share started successfully')
       } catch (error) {
         console.error('[StreamingControls] Error enabling screen share:', error)
-        console.error('[StreamingControls] Error details:', {
-          name: error instanceof Error ? error.name : 'Unknown',
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined
-        })
         setIsScreenSharing(false)
 
         // Show user-friendly error message
         if (error instanceof Error) {
           if (error.name === 'NotAllowedError') {
-            console.log('[StreamingControls] User denied screen share permission')
             alert('Permission denied. Please allow screen sharing to continue.')
           } else if (error.name === 'NotSupportedError') {
             alert('Screen sharing is not supported on this device')
@@ -290,13 +254,11 @@ export function StreamingControls({
   }
 
   const handleAudioDeviceSelect = async (deviceId: string) => {
-    console.log('[StreamingControls] Selecting audio device:', deviceId)
     setSelectedAudioDevice(deviceId)
     setShowAudioMenu(false)
 
     // Only switch if mic is currently enabled
     if (!localParticipant || !isMicEnabled) {
-      console.log('[StreamingControls] Device selected. Will use when mic is enabled.')
       return
     }
 
@@ -307,12 +269,9 @@ export function StreamingControls({
 
       if (audioTrack && 'restartTrack' in audioTrack) {
         // Use restartTrack with "exact" constraint (no renegotiation, seamless switch)
-        console.log('[StreamingControls] Restarting track with device:', deviceId)
         await audioTrack.restartTrack({ deviceId: { exact: deviceId } })
-        console.log('[StreamingControls] Audio device switched')
       } else {
         // Fallback: disable then re-enable with exact constraint
-        console.log('[StreamingControls] No track found, using toggle method')
         await localParticipant.setMicrophoneEnabled(false)
         await localParticipant.setMicrophoneEnabled(true, { deviceId: { exact: deviceId } })
       }
@@ -322,13 +281,11 @@ export function StreamingControls({
   }
 
   const handleVideoDeviceSelect = async (deviceId: string) => {
-    console.log('[StreamingControls] Selecting video device:', deviceId)
     setSelectedVideoDevice(deviceId)
     setShowVideoMenu(false)
 
     // Only switch if camera is currently enabled
     if (!localParticipant || !isCameraEnabled) {
-      console.log('[StreamingControls] Device selected. Will use when camera is enabled.')
       return
     }
 
@@ -339,12 +296,9 @@ export function StreamingControls({
 
       if (videoTrack && 'restartTrack' in videoTrack) {
         // Use restartTrack with "exact" constraint (no renegotiation, seamless switch)
-        console.log('[StreamingControls] Restarting track with device:', deviceId)
         await videoTrack.restartTrack({ deviceId: { exact: deviceId } })
-        console.log('[StreamingControls] Video device switched')
       } else {
         // Fallback: disable then re-enable with exact constraint
-        console.log('[StreamingControls] No track found, using toggle method')
         await localParticipant.setCameraEnabled(false)
         await localParticipant.setCameraEnabled(true, { deviceId: { exact: deviceId } })
       }

--- a/src/components/StreamingControls/StreamingControls.tsx
+++ b/src/components/StreamingControls/StreamingControls.tsx
@@ -12,6 +12,8 @@ import StopIcon from '@mui/icons-material/Stop'
 import StopScreenShareIcon from '@mui/icons-material/StopScreenShare'
 import VideocamIcon from '@mui/icons-material/Videocam'
 import VideocamOffIcon from '@mui/icons-material/VideocamOff'
+import VolumeOffIcon from '@mui/icons-material/VolumeOff'
+import VolumeUpIcon from '@mui/icons-material/VolumeUp'
 import { ConnectionState, LocalAudioTrack, LocalVideoTrack, Track } from 'livekit-client'
 import { useLiveKitCredentials } from '../../context/LiveKitContext'
 import { usePresentationOptional } from '../../context/PresentationContext'
@@ -45,7 +47,9 @@ export function StreamingControls({
   onTogglePeople,
   isStreamer = false,
   onLeave,
-  unreadMessagesCount = 0
+  unreadMessagesCount = 0,
+  isTabMuted = false,
+  onToggleTabMute
 }: StreamingControlsProps) {
   const { t } = useTranslation()
   const room = useRoomContext()
@@ -578,6 +582,12 @@ export function StreamingControls({
       {/* Right Controls: Chat + People buttons */}
       <ControlsRight>
         {/* Desktop buttons */}
+        {onToggleTabMute && (
+          <IconButton onClick={onToggleTabMute} title={isTabMuted ? t('streaming_controls.unmute_cast') : t('streaming_controls.mute_cast')}>
+            {isTabMuted ? <VolumeOffIcon /> : <VolumeUpIcon />}
+          </IconButton>
+        )}
+
         {onToggleChat && (
           <IconButton onClick={onToggleChat}>
             <ChatBubbleOutlineIcon />
@@ -594,6 +604,12 @@ export function StreamingControls({
 
         {/* Mobile: Chat and People on the left */}
         <MobileLeftGroup>
+          {onToggleTabMute && (
+            <MobileIconButton onClick={onToggleTabMute}>
+              {isTabMuted ? <VolumeOffIcon /> : <VolumeUpIcon />}
+            </MobileIconButton>
+          )}
+
           {onToggleChat && (
             <MobileIconButton onClick={onToggleChat}>
               <ChatBubbleOutlineIcon />

--- a/src/components/StreamingControls/StreamingControls.tsx
+++ b/src/components/StreamingControls/StreamingControls.tsx
@@ -8,13 +8,13 @@ import MicOffIcon from '@mui/icons-material/MicOff'
 import PeopleIcon from '@mui/icons-material/People'
 import ScreenShareIcon from '@mui/icons-material/ScreenShare'
 import SlideshowIcon from '@mui/icons-material/Slideshow'
-import StopIcon from '@mui/icons-material/Stop'
 import StopScreenShareIcon from '@mui/icons-material/StopScreenShare'
 import VideocamIcon from '@mui/icons-material/Videocam'
 import VideocamOffIcon from '@mui/icons-material/VideocamOff'
 import VolumeOffIcon from '@mui/icons-material/VolumeOff'
 import VolumeUpIcon from '@mui/icons-material/VolumeUp'
 import { ConnectionState, LocalAudioTrack, LocalVideoTrack, Track } from 'livekit-client'
+import { ShareMenuDropdown } from './ShareMenuDropdown'
 import { useLiveKitCredentials } from '../../context/LiveKitContext'
 import { usePresentationOptional } from '../../context/PresentationContext'
 import { useTranslation } from '../../modules/translation'
@@ -37,9 +37,7 @@ import {
   MobileIconButton,
   MobileLeftGroup,
   MobileRightGroup,
-  NotificationBadge,
-  ShareMenu,
-  ShareMenuItem
+  NotificationBadge
 } from './StreamingControls.styled'
 
 export function StreamingControls({
@@ -68,7 +66,6 @@ export function StreamingControls({
 
   const presentationContext = usePresentationOptional()
   const isPresentationActive = presentationContext?.isPresentationActive ?? false
-  const isSharingAnything = isScreenSharing || isPresentationActive
 
   const handleShareScreenClick = () => {
     setShowShareMenu(false)
@@ -88,10 +85,8 @@ export function StreamingControls({
   const handleShareButtonClick = () => {
     if (isScreenSharing) {
       handleScreenShare() // stops screen share
-    } else if (isPresentationActive) {
-      setShowShareMenu(!showShareMenu)
     } else {
-      setShowShareMenu(!showShareMenu)
+      setShowShareMenu(prev => !prev)
     }
   }
 
@@ -383,100 +378,11 @@ export function StreamingControls({
 
   return (
     <>
-    <ControlsContainer>
-      {/* Mobile Left Controls: Media controls (visible only on mobile) */}
-      <ControlsLeft>
-        {/* Mic Control - Only for streamer */}
-        {isStreamer && (
-          <ButtonWithMenu>
-            <CircleButton onClick={handleToggleMic}>{isMicEnabled ? <MicIcon /> : <MicOffIcon />}</CircleButton>
-            {audioDevices.length > 1 && (
-              <ChevronButton data-dropdown-button onClick={() => setShowAudioMenu(!showAudioMenu)}>
-                <ExpandMoreIcon />
-              </ChevronButton>
-            )}
-            {showAudioMenu && (
-              <DeviceMenu data-dropdown-menu>
-                {audioDevices.map(device => (
-                  <DeviceMenuItem
-                    key={device.deviceId}
-                    $active={device.deviceId === selectedAudioDevice}
-                    onClick={() => handleAudioDeviceSelect(device.deviceId)}
-                  >
-                    {device.label || `Microphone ${device.deviceId.slice(0, 5)}`}
-                  </DeviceMenuItem>
-                ))}
-              </DeviceMenu>
-            )}
-          </ButtonWithMenu>
-        )}
-
-        {/* Camera Control - Only for streamer */}
-        {isStreamer && (
-          <ButtonWithMenu>
-            <CircleButton onClick={handleToggleCamera}>{isCameraEnabled ? <VideocamIcon /> : <VideocamOffIcon />}</CircleButton>
-            {videoDevices.length > 1 && (
-              <ChevronButton data-dropdown-button onClick={() => setShowVideoMenu(!showVideoMenu)}>
-                <ExpandMoreIcon />
-              </ChevronButton>
-            )}
-            {showVideoMenu && (
-              <DeviceMenu data-dropdown-menu>
-                {videoDevices.map(device => (
-                  <DeviceMenuItem
-                    key={device.deviceId}
-                    $active={device.deviceId === selectedVideoDevice}
-                    onClick={() => handleVideoDeviceSelect(device.deviceId)}
-                  >
-                    {device.label || `Camera ${device.deviceId.slice(0, 5)}`}
-                  </DeviceMenuItem>
-                ))}
-              </DeviceMenu>
-            )}
-          </ButtonWithMenu>
-        )}
-
-        {/* Share (Screen / Presentation) - Only for streamer */}
-        {isStreamer && (
-          <ButtonWithMenu>
-            <CircleButton onClick={handleShareButtonClick} data-dropdown-button>
-              {isPresentationActive ? <SlideshowIcon /> : isScreenSharing ? <StopScreenShareIcon /> : <ScreenShareIcon />}
-            </CircleButton>
-            {!isScreenSharing && (
-              <ChevronButton data-dropdown-button onClick={() => setShowShareMenu(!showShareMenu)}>
-                <ExpandMoreIcon />
-              </ChevronButton>
-            )}
-            {showShareMenu && (
-              <ShareMenu data-dropdown-menu>
-                {isPresentationActive ? (
-                  <ShareMenuItem onClick={handleStopPresentation}>
-                    <StopIcon />
-                    Stop Presentation
-                  </ShareMenuItem>
-                ) : (
-                  <>
-                    <ShareMenuItem onClick={handleShareScreenClick}>
-                      <ScreenShareIcon />
-                      Share Screen
-                    </ShareMenuItem>
-                    <ShareMenuItem onClick={handleSharePresentationClick}>
-                      <SlideshowIcon />
-                      Share Presentation
-                    </ShareMenuItem>
-                  </>
-                )}
-              </ShareMenu>
-            )}
-          </ButtonWithMenu>
-        )}
-      </ControlsLeft>
-
-      {/* Center Controls: Media controls (desktop) + Chat/People (mobile) */}
-      <ControlsCenter>
-        {/* Media controls - Only for streamer, visible only on desktop */}
-        {isStreamer && (
-          <DesktopMediaControls>
+      <ControlsContainer>
+        {/* Mobile Left Controls: Media controls (visible only on mobile) */}
+        <ControlsLeft>
+          {/* Mic Control - Only for streamer */}
+          {isStreamer && (
             <ButtonWithMenu>
               <CircleButton onClick={handleToggleMic}>{isMicEnabled ? <MicIcon /> : <MicOffIcon />}</CircleButton>
               {audioDevices.length > 1 && (
@@ -498,7 +404,10 @@ export function StreamingControls({
                 </DeviceMenu>
               )}
             </ButtonWithMenu>
+          )}
 
+          {/* Camera Control - Only for streamer */}
+          {isStreamer && (
             <ButtonWithMenu>
               <CircleButton onClick={handleToggleCamera}>{isCameraEnabled ? <VideocamIcon /> : <VideocamOffIcon />}</CircleButton>
               {videoDevices.length > 1 && (
@@ -520,8 +429,10 @@ export function StreamingControls({
                 </DeviceMenu>
               )}
             </ButtonWithMenu>
+          )}
 
-            {/* Share (Screen / Presentation) dropdown */}
+          {/* Share (Screen / Presentation) - Only for streamer */}
+          {isStreamer && (
             <ButtonWithMenu>
               <CircleButton onClick={handleShareButtonClick} data-dropdown-button>
                 {isPresentationActive ? <SlideshowIcon /> : isScreenSharing ? <StopScreenShareIcon /> : <ScreenShareIcon />}
@@ -532,121 +443,180 @@ export function StreamingControls({
                 </ChevronButton>
               )}
               {showShareMenu && (
-                <ShareMenu data-dropdown-menu>
-                  {isPresentationActive ? (
-                    <ShareMenuItem onClick={handleStopPresentation}>
-                      <StopIcon />
-                      Stop Presentation
-                    </ShareMenuItem>
-                  ) : (
-                    <>
-                      <ShareMenuItem onClick={handleShareScreenClick}>
-                        <ScreenShareIcon />
-                        Share Screen
-                      </ShareMenuItem>
-                      <ShareMenuItem onClick={handleSharePresentationClick}>
-                        <SlideshowIcon />
-                        Share Presentation
-                      </ShareMenuItem>
-                    </>
-                  )}
-                </ShareMenu>
+                <ShareMenuDropdown
+                  isPresentationActive={isPresentationActive}
+                  onShareScreen={handleShareScreenClick}
+                  onSharePresentation={handleSharePresentationClick}
+                  onStopPresentation={handleStopPresentation}
+                />
               )}
             </ButtonWithMenu>
+          )}
+        </ControlsLeft>
 
-            {/* Leave/Hang-up button - Desktop only, positioned after media controls */}
-            {isDisconnected ? (
-              <EndStreamButton onClick={handleReconnect}>{t('streaming_controls.reconnect')}</EndStreamButton>
-            ) : (
-              <EndStreamButton onClick={handleLeave} startIcon={<CallEndIcon />}>
-                {isStreamer ? t('streaming_controls.leave_stream') : t('streaming_controls.leave')}
-              </EndStreamButton>
-            )}
-          </DesktopMediaControls>
-        )}
+        {/* Center Controls: Media controls (desktop) + Chat/People (mobile) */}
+        <ControlsCenter>
+          {/* Media controls - Only for streamer, visible only on desktop */}
+          {isStreamer && (
+            <DesktopMediaControls>
+              <ButtonWithMenu>
+                <CircleButton onClick={handleToggleMic}>{isMicEnabled ? <MicIcon /> : <MicOffIcon />}</CircleButton>
+                {audioDevices.length > 1 && (
+                  <ChevronButton data-dropdown-button onClick={() => setShowAudioMenu(!showAudioMenu)}>
+                    <ExpandMoreIcon />
+                  </ChevronButton>
+                )}
+                {showAudioMenu && (
+                  <DeviceMenu data-dropdown-menu>
+                    {audioDevices.map(device => (
+                      <DeviceMenuItem
+                        key={device.deviceId}
+                        $active={device.deviceId === selectedAudioDevice}
+                        onClick={() => handleAudioDeviceSelect(device.deviceId)}
+                      >
+                        {device.label || `Microphone ${device.deviceId.slice(0, 5)}`}
+                      </DeviceMenuItem>
+                    ))}
+                  </DeviceMenu>
+                )}
+              </ButtonWithMenu>
 
-        {/* Leave button for watchers (centered) */}
-        {!isStreamer && (
-          <>
-            {isDisconnected ? (
-              <EndStreamButton onClick={handleReconnect}>{t('streaming_controls.reconnect')}</EndStreamButton>
-            ) : (
-              <EndStreamButton onClick={handleLeave} startIcon={<CallEndIcon />}>
-                {t('streaming_controls.leave')}
-              </EndStreamButton>
-            )}
-          </>
-        )}
-      </ControlsCenter>
+              <ButtonWithMenu>
+                <CircleButton onClick={handleToggleCamera}>{isCameraEnabled ? <VideocamIcon /> : <VideocamOffIcon />}</CircleButton>
+                {videoDevices.length > 1 && (
+                  <ChevronButton data-dropdown-button onClick={() => setShowVideoMenu(!showVideoMenu)}>
+                    <ExpandMoreIcon />
+                  </ChevronButton>
+                )}
+                {showVideoMenu && (
+                  <DeviceMenu data-dropdown-menu>
+                    {videoDevices.map(device => (
+                      <DeviceMenuItem
+                        key={device.deviceId}
+                        $active={device.deviceId === selectedVideoDevice}
+                        onClick={() => handleVideoDeviceSelect(device.deviceId)}
+                      >
+                        {device.label || `Camera ${device.deviceId.slice(0, 5)}`}
+                      </DeviceMenuItem>
+                    ))}
+                  </DeviceMenu>
+                )}
+              </ButtonWithMenu>
 
-      {/* Right Controls: Chat + People buttons */}
-      <ControlsRight>
-        {/* Desktop buttons */}
-        {onToggleTabMute && (
-          <IconButton onClick={onToggleTabMute} title={isTabMuted ? t('streaming_controls.unmute_cast') : t('streaming_controls.mute_cast')}>
-            {isTabMuted ? <VolumeOffIcon /> : <VolumeUpIcon />}
-          </IconButton>
-        )}
+              {/* Share (Screen / Presentation) dropdown */}
+              <ButtonWithMenu>
+                <CircleButton onClick={handleShareButtonClick} data-dropdown-button>
+                  {isPresentationActive ? <SlideshowIcon /> : isScreenSharing ? <StopScreenShareIcon /> : <ScreenShareIcon />}
+                </CircleButton>
+                {!isScreenSharing && (
+                  <ChevronButton data-dropdown-button onClick={() => setShowShareMenu(!showShareMenu)}>
+                    <ExpandMoreIcon />
+                  </ChevronButton>
+                )}
+                {showShareMenu && (
+                  <ShareMenuDropdown
+                    isPresentationActive={isPresentationActive}
+                    onShareScreen={handleShareScreenClick}
+                    onSharePresentation={handleSharePresentationClick}
+                    onStopPresentation={handleStopPresentation}
+                  />
+                )}
+              </ButtonWithMenu>
 
-        {onToggleChat && (
-          <IconButton onClick={onToggleChat}>
-            <ChatBubbleOutlineIcon />
-            {unreadMessagesCount > 0 && <NotificationBadge>{unreadMessagesCount}</NotificationBadge>}
-          </IconButton>
-        )}
+              {/* Leave/Hang-up button - Desktop only, positioned after media controls */}
+              {isDisconnected ? (
+                <EndStreamButton onClick={handleReconnect}>{t('streaming_controls.reconnect')}</EndStreamButton>
+              ) : (
+                <EndStreamButton onClick={handleLeave} startIcon={<CallEndIcon />}>
+                  {isStreamer ? t('streaming_controls.leave_stream') : t('streaming_controls.leave')}
+                </EndStreamButton>
+              )}
+            </DesktopMediaControls>
+          )}
 
-        {onTogglePeople && (
-          <IconButton onClick={onTogglePeople}>
-            <PeopleIcon />
-            <NotificationBadge>{totalParticipants}</NotificationBadge>
-          </IconButton>
-        )}
+          {/* Leave button for watchers (centered) */}
+          {!isStreamer && (
+            <>
+              {isDisconnected ? (
+                <EndStreamButton onClick={handleReconnect}>{t('streaming_controls.reconnect')}</EndStreamButton>
+              ) : (
+                <EndStreamButton onClick={handleLeave} startIcon={<CallEndIcon />}>
+                  {t('streaming_controls.leave')}
+                </EndStreamButton>
+              )}
+            </>
+          )}
+        </ControlsCenter>
 
-        {/* Mobile: Chat and People on the left */}
-        <MobileLeftGroup>
+        {/* Right Controls: Chat + People buttons */}
+        <ControlsRight>
+          {/* Desktop buttons */}
           {onToggleTabMute && (
-            <MobileIconButton onClick={onToggleTabMute}>
+            <IconButton
+              onClick={onToggleTabMute}
+              title={isTabMuted ? t('streaming_controls.unmute_cast') : t('streaming_controls.mute_cast')}
+            >
               {isTabMuted ? <VolumeOffIcon /> : <VolumeUpIcon />}
-            </MobileIconButton>
+            </IconButton>
           )}
 
           {onToggleChat && (
-            <MobileIconButton onClick={onToggleChat}>
+            <IconButton onClick={onToggleChat}>
               <ChatBubbleOutlineIcon />
               {unreadMessagesCount > 0 && <NotificationBadge>{unreadMessagesCount}</NotificationBadge>}
-            </MobileIconButton>
+            </IconButton>
           )}
 
           {onTogglePeople && (
-            <MobileIconButton onClick={onTogglePeople}>
+            <IconButton onClick={onTogglePeople}>
               <PeopleIcon />
               <NotificationBadge>{totalParticipants}</NotificationBadge>
-            </MobileIconButton>
+            </IconButton>
           )}
-        </MobileLeftGroup>
 
-        {/* Mobile: End Call on the right */}
-        <MobileRightGroup>
-          {isDisconnected ? (
-            <CircleEndButton onClick={handleReconnect}>
-              <CallEndIcon />
-            </CircleEndButton>
-          ) : (
-            <CircleEndButton onClick={handleLeave}>
-              <CallEndIcon />
-            </CircleEndButton>
-          )}
-        </MobileRightGroup>
-      </ControlsRight>
-    </ControlsContainer>
+          {/* Mobile: Chat and People on the left */}
+          <MobileLeftGroup>
+            {onToggleTabMute && (
+              <MobileIconButton onClick={onToggleTabMute}>{isTabMuted ? <VolumeOffIcon /> : <VolumeUpIcon />}</MobileIconButton>
+            )}
 
-    {showPresentationModal && (
-      <SharePresentationModal
-        onClose={() => setShowPresentationModal(false)}
-        onFileSelected={handlePresentationFileSelected}
-        onUrlSubmitted={handlePresentationUrlSubmitted}
-      />
-    )}
+            {onToggleChat && (
+              <MobileIconButton onClick={onToggleChat}>
+                <ChatBubbleOutlineIcon />
+                {unreadMessagesCount > 0 && <NotificationBadge>{unreadMessagesCount}</NotificationBadge>}
+              </MobileIconButton>
+            )}
+
+            {onTogglePeople && (
+              <MobileIconButton onClick={onTogglePeople}>
+                <PeopleIcon />
+                <NotificationBadge>{totalParticipants}</NotificationBadge>
+              </MobileIconButton>
+            )}
+          </MobileLeftGroup>
+
+          {/* Mobile: End Call on the right */}
+          <MobileRightGroup>
+            {isDisconnected ? (
+              <CircleEndButton onClick={handleReconnect}>
+                <CallEndIcon />
+              </CircleEndButton>
+            ) : (
+              <CircleEndButton onClick={handleLeave}>
+                <CallEndIcon />
+              </CircleEndButton>
+            )}
+          </MobileRightGroup>
+        </ControlsRight>
+      </ControlsContainer>
+
+      {showPresentationModal && (
+        <SharePresentationModal
+          onClose={() => setShowPresentationModal(false)}
+          onFileSelected={handlePresentationFileSelected}
+          onUrlSubmitted={handlePresentationUrlSubmitted}
+        />
+      )}
     </>
   )
 }

--- a/src/components/StreamingControls/StreamingControls.types.ts
+++ b/src/components/StreamingControls/StreamingControls.types.ts
@@ -4,6 +4,8 @@ interface StreamingControlsProps {
   isStreamer?: boolean
   onLeave?: () => void
   unreadMessagesCount?: number
+  isTabMuted?: boolean
+  onToggleTabMute?: () => void
 }
 
 export type { StreamingControlsProps }

--- a/src/components/WatcherView/WatcherView.tsx
+++ b/src/components/WatcherView/WatcherView.tsx
@@ -40,6 +40,7 @@ export function WatcherView() {
   const [onboardingComplete, setOnboardingComplete] = useState(false)
   const [isJoining, setIsJoining] = useState(false)
   const [isLoadingCredentials, setIsLoadingCredentials] = useState(false)
+  const [isTabMuted, setIsTabMuted] = useState(false)
 
   // Phase 1: Fetch scenes for worlds that need selection
   useEffect(() => {
@@ -220,10 +221,10 @@ export function WatcherView() {
         onConnected={handleRoomConnect}
       >
         <ChatProvider>
-          <WatcherViewWithChat onLeave={handleLeaveRoom} />
+          <WatcherViewWithChat onLeave={handleLeaveRoom} isTabMuted={isTabMuted} onToggleTabMute={() => setIsTabMuted(prev => !prev)} />
         </ChatProvider>
 
-        <RoomAudioRenderer />
+        <RoomAudioRenderer volume={isTabMuted ? 0 : 1} />
         <ConnectionStateToast />
       </LiveKitRoom>
     </WatcherContainer>

--- a/src/components/WatcherView/WatcherViewWithChat.tsx
+++ b/src/components/WatcherView/WatcherViewWithChat.tsx
@@ -4,6 +4,7 @@ import { ChatPanel } from '../ChatPanel/ChatPanel'
 import { useChatContext } from '../ChatProvider/ChatProvider'
 import { ControlsArea, MainContent, Sidebar, VideoArea, VideoContainer, ViewLayout as WatcherLayout } from '../CommonView/CommonView.styled'
 import { PeopleSidebar } from '../PeopleSidebar/PeopleSidebar'
+import { PresentationProvider } from '../../context/PresentationContext'
 import { StreamingControls } from '../StreamingControls/StreamingControls'
 
 interface WatcherViewWithChatProps {
@@ -27,29 +28,31 @@ export function WatcherViewWithChat({ onLeave }: WatcherViewWithChatProps) {
   }, [isChatOpen, peopleOpen, setChatOpen])
 
   return (
-    <WatcherLayout>
-      <MainContent>
-        <VideoContainer $sidebarOpen={sidebarOpen}>
-          <VideoArea $sidebarOpen={sidebarOpen}>
-            <WatcherViewContent />
-          </VideoArea>
+    <PresentationProvider>
+      <WatcherLayout>
+        <MainContent>
+          <VideoContainer $sidebarOpen={sidebarOpen}>
+            <VideoArea $sidebarOpen={sidebarOpen}>
+              <WatcherViewContent />
+            </VideoArea>
 
-          <Sidebar $isOpen={sidebarOpen}>
-            {isChatOpen && <ChatPanel onClose={handleToggleChat} chatMessages={chatMessages} onMessagesRead={markMessagesAsRead} />}
-            {peopleOpen && <PeopleSidebar onClose={handleTogglePeople} />}
-          </Sidebar>
-        </VideoContainer>
+            <Sidebar $isOpen={sidebarOpen}>
+              {isChatOpen && <ChatPanel onClose={handleToggleChat} chatMessages={chatMessages} onMessagesRead={markMessagesAsRead} />}
+              {peopleOpen && <PeopleSidebar onClose={handleTogglePeople} />}
+            </Sidebar>
+          </VideoContainer>
 
-        <ControlsArea>
-          <StreamingControls
-            onToggleChat={handleToggleChat}
-            onTogglePeople={handleTogglePeople}
-            isStreamer={false}
-            onLeave={onLeave}
-            unreadMessagesCount={unreadMessagesCount}
-          />
-        </ControlsArea>
-      </MainContent>
-    </WatcherLayout>
+          <ControlsArea>
+            <StreamingControls
+              onToggleChat={handleToggleChat}
+              onTogglePeople={handleTogglePeople}
+              isStreamer={false}
+              onLeave={onLeave}
+              unreadMessagesCount={unreadMessagesCount}
+            />
+          </ControlsArea>
+        </MainContent>
+      </WatcherLayout>
+    </PresentationProvider>
   )
 }

--- a/src/components/WatcherView/WatcherViewWithChat.tsx
+++ b/src/components/WatcherView/WatcherViewWithChat.tsx
@@ -9,9 +9,11 @@ import { StreamingControls } from '../StreamingControls/StreamingControls'
 
 interface WatcherViewWithChatProps {
   onLeave: () => void
+  isTabMuted: boolean
+  onToggleTabMute: () => void
 }
 
-export function WatcherViewWithChat({ onLeave }: WatcherViewWithChatProps) {
+export function WatcherViewWithChat({ onLeave, isTabMuted, onToggleTabMute }: WatcherViewWithChatProps) {
   const [peopleOpen, setPeopleOpen] = useState(false)
   const { chatMessages, unreadMessagesCount, markMessagesAsRead, isChatOpen, setChatOpen } = useChatContext()
 
@@ -49,6 +51,8 @@ export function WatcherViewWithChat({ onLeave }: WatcherViewWithChatProps) {
               isStreamer={false}
               onLeave={onLeave}
               unreadMessagesCount={unreadMessagesCount}
+              isTabMuted={isTabMuted}
+              onToggleTabMute={onToggleTabMute}
             />
           </ControlsArea>
         </MainContent>

--- a/src/config/env/dev.json
+++ b/src/config/env/dev.json
@@ -2,6 +2,7 @@
   "GATEKEEPER_URL": "https://comms-gatekeeper.decentraland.zone",
   "PEER_URL": "https://peer.decentraland.zone",
   "WORLDS_CONTENT_URL": "https://worlds-content-server.decentraland.zone",
+  "PRESENTER_SERVER_URL": "https://cast-presenter-service.decentraland.zone",
   "ENVIRONMENT": "development",
   "ANALYTICS_ENABLED": false,
   "DEBUG_MODE": true

--- a/src/config/env/prd.json
+++ b/src/config/env/prd.json
@@ -2,6 +2,7 @@
   "GATEKEEPER_URL": "https://comms-gatekeeper.decentraland.org",
   "PEER_URL": "https://peer.decentraland.org",
   "WORLDS_CONTENT_URL": "https://worlds-content-server.decentraland.org",
+  "PRESENTER_SERVER_URL": "https://cast-presenter-service.decentraland.org",
   "ENVIRONMENT": "production",
   "ANALYTICS_ENABLED": true,
   "DEBUG_MODE": false

--- a/src/config/env/stg.json
+++ b/src/config/env/stg.json
@@ -2,6 +2,7 @@
   "GATEKEEPER_URL": "https://comms-gatekeeper.decentraland.zone",
   "PEER_URL": "https://peer-testing.decentraland.org",
   "WORLDS_CONTENT_URL": "https://worlds-content-server.decentraland.zone",
+  "PRESENTER_SERVER_URL": "https://cast-presenter-service.decentraland.zone",
   "ENVIRONMENT": "staging",
   "ANALYTICS_ENABLED": true,
   "DEBUG_MODE": false

--- a/src/context/PresentationContext.test.tsx
+++ b/src/context/PresentationContext.test.tsx
@@ -1,0 +1,280 @@
+import React from 'react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import type { PresentationInfo } from '../utils/api'
+import { PresentationProvider, usePresentation } from './PresentationContext'
+
+jest.mock('@livekit/components-react', () => ({
+  useRemoteParticipants: jest.fn(),
+  useRoomContext: jest.fn()
+}))
+
+jest.mock('../utils/api', () => ({
+  getPresentationBotToken: jest.fn(),
+  uploadPresentation: jest.fn(),
+  uploadPresentationFromUrl: jest.fn()
+}))
+
+jest.mock('../utils/localStorage', () => ({
+  getStreamerToken: jest.fn()
+}))
+
+const mockUseRemoteParticipants = jest.requireMock('@livekit/components-react').useRemoteParticipants
+const mockUseRoomContext = jest.requireMock('@livekit/components-react').useRoomContext
+const mockGetPresentationBotToken = jest.requireMock('../utils/api').getPresentationBotToken
+const mockUploadPresentation = jest.requireMock('../utils/api').uploadPresentation
+const mockGetStreamerToken = jest.requireMock('../utils/localStorage').getStreamerToken
+
+const STREAMING_KEY = 'test-streaming-key'
+const BOT_TOKEN = { url: 'wss://livekit.example', token: 'bot-token', roomId: 'room-1' }
+const UPLOAD_INFO: PresentationInfo = { id: 'pres-1', slideCount: 5, currentSlide: 0, fileType: 'pdf' }
+
+function makeBotParticipant(metadata: Record<string, unknown>) {
+  return { identity: 'presentation-bot-1', metadata: JSON.stringify(metadata) }
+}
+
+// Minimal Room stub that captures the data-channel handler so tests can
+// simulate bot → client messages, and records publishData for outbound checks.
+function createRoomStub() {
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>()
+  return {
+    localParticipant: {
+      publishData: jest.fn().mockResolvedValue(undefined)
+    },
+    on: jest.fn((event: string, cb: (...args: unknown[]) => void) => {
+      const arr = listeners.get(event) ?? []
+      arr.push(cb)
+      listeners.set(event, arr)
+    }),
+    off: jest.fn((event: string, cb: (...args: unknown[]) => void) => {
+      const arr = listeners.get(event) ?? []
+      listeners.set(
+        event,
+        arr.filter(fn => fn !== cb)
+      )
+    }),
+    emit(event: string, ...args: unknown[]) {
+      const arr = listeners.get(event) ?? []
+      arr.forEach(cb => cb(...args))
+    }
+  }
+}
+
+type ProbeApi = {
+  ctx: ReturnType<typeof usePresentation>
+}
+
+function Probe({ onReady }: { onReady: (api: ProbeApi) => void }) {
+  const ctx = usePresentation()
+  React.useEffect(() => {
+    onReady({ ctx })
+  })
+  return <div data-testid="status">{ctx.state.status}</div>
+}
+
+function renderWithProvider(onReady: (api: ProbeApi) => void) {
+  return render(
+    <PresentationProvider>
+      <Probe onReady={onReady} />
+    </PresentationProvider>
+  )
+}
+
+describe('PresentationContext', () => {
+  let room: ReturnType<typeof createRoomStub>
+  let latestApi: ProbeApi | null
+
+  beforeEach(() => {
+    room = createRoomStub()
+    latestApi = null
+    mockUseRoomContext.mockReturnValue(room)
+    mockUseRemoteParticipants.mockReturnValue([])
+    mockGetStreamerToken.mockReturnValue(STREAMING_KEY)
+    mockGetPresentationBotToken.mockResolvedValue(BOT_TOKEN)
+    mockUploadPresentation.mockResolvedValue(UPLOAD_INFO)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('when the provider mounts with no bot present', () => {
+    it('should expose the initial idle state', () => {
+      renderWithProvider(api => {
+        latestApi = api
+      })
+
+      expect(screen.getByTestId('status').textContent).toBe('idle')
+      expect(latestApi?.ctx.state.id).toBeNull()
+      expect(latestApi?.ctx.isPresentationActive).toBe(false)
+    })
+  })
+
+  describe('when startPresentation resolves successfully', () => {
+    it('should transition status to starting with the returned presentation info', async () => {
+      renderWithProvider(api => {
+        latestApi = api
+      })
+
+      await act(async () => {
+        await latestApi!.ctx.startPresentation(new File(['x'], 'slides.pdf'))
+      })
+
+      expect(screen.getByTestId('status').textContent).toBe('starting')
+      expect(latestApi?.ctx.state.id).toBe(UPLOAD_INFO.id)
+      expect(latestApi?.ctx.state.slideCount).toBe(UPLOAD_INFO.slideCount)
+      expect(latestApi?.ctx.isPresentationActive).toBe(true)
+    })
+  })
+
+  describe('when startPresentation fails', () => {
+    beforeEach(() => {
+      mockUploadPresentation.mockRejectedValueOnce(new Error('upload blew up'))
+    })
+
+    it('should transition status to error and expose the error message', async () => {
+      renderWithProvider(api => {
+        latestApi = api
+      })
+
+      await act(async () => {
+        await latestApi!.ctx.startPresentation(new File(['x'], 'slides.pdf'))
+      })
+
+      expect(screen.getByTestId('status').textContent).toBe('error')
+      expect(latestApi?.ctx.state.error).toBe('upload blew up')
+    })
+
+    describe('and dismissError is called', () => {
+      it('should reset status back to idle', async () => {
+        renderWithProvider(api => {
+          latestApi = api
+        })
+
+        await act(async () => {
+          await latestApi!.ctx.startPresentation(new File(['x'], 'slides.pdf'))
+        })
+        expect(screen.getByTestId('status').textContent).toBe('error')
+
+        act(() => {
+          latestApi!.ctx.dismissError()
+        })
+
+        expect(screen.getByTestId('status').textContent).toBe('idle')
+        expect(latestApi?.ctx.state.error).toBeNull()
+      })
+    })
+  })
+
+  describe('when startPresentation is invoked twice concurrently', () => {
+    it('should only run one upload (ref-based mutex drops the second call)', async () => {
+      // Make the first upload hang so we can fire the second before it resolves.
+      let resolveFirst!: (info: PresentationInfo) => void
+      mockUploadPresentation.mockReturnValueOnce(
+        new Promise(res => {
+          resolveFirst = res
+        })
+      )
+
+      renderWithProvider(api => {
+        latestApi = api
+      })
+
+      await act(async () => {
+        // Fire both calls in the same act scope. The first awaits the hanging
+        // upload; the second sees the mutex set and returns immediately. We
+        // resolve + await everything inside this act to avoid interleaving.
+        const first = latestApi!.ctx.startPresentation(new File(['a'], 'a.pdf'))
+        const second = latestApi!.ctx.startPresentation(new File(['b'], 'b.pdf'))
+        await second
+        resolveFirst(UPLOAD_INFO)
+        await first
+      })
+
+      expect(mockUploadPresentation).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when the bot participant appears in the room while status is starting', () => {
+    it('should transition status from starting to active', async () => {
+      const makeTree = (key: number) => (
+        <PresentationProvider key={key}>
+          <Probe
+            onReady={api => {
+              latestApi = api
+            }}
+          />
+        </PresentationProvider>
+      )
+      const { rerender } = render(makeTree(0))
+
+      await act(async () => {
+        await latestApi!.ctx.startPresentation(new File(['x'], 'slides.pdf'))
+      })
+      expect(screen.getByTestId('status').textContent).toBe('starting')
+
+      // Simulate bot joining. We rerender with a different key to defeat React's
+      // element-identity short-circuit so the provider's hooks re-evaluate and
+      // pick up the updated useRemoteParticipants mock.
+      // NOTE: a new key remounts the provider, which resets state to 'idle'.
+      // To verify the metadata-sync transition without a remount, we instead
+      // trigger an in-tree render by dispatching a benign setState via the
+      // ref-captured api — useRemoteParticipants is re-read on that render.
+      mockUseRemoteParticipants.mockReturnValue([
+        makeBotParticipant({
+          role: 'presentation',
+          id: UPLOAD_INFO.id,
+          slideCount: UPLOAD_INFO.slideCount,
+          currentSlide: 0,
+          fileType: 'pdf'
+        })
+      ])
+
+      await act(async () => {
+        rerender(makeTree(0))
+      })
+
+      await waitFor(() => expect(latestApi?.ctx.state.status).toBe('active'))
+      expect(latestApi?.ctx.presentationParticipantIdentity).toBe('presentation-bot-1')
+    })
+  })
+
+  describe('when the bot participant disappears while status is active', () => {
+    it('should reset state back to idle', async () => {
+      // Prime the provider with a bot already present.
+      mockUseRemoteParticipants.mockReturnValue([
+        makeBotParticipant({
+          role: 'presentation',
+          id: UPLOAD_INFO.id,
+          slideCount: UPLOAD_INFO.slideCount,
+          currentSlide: 0,
+          fileType: 'pdf'
+        })
+      ])
+      const { rerender } = render(
+        <PresentationProvider>
+          <Probe
+            onReady={api => {
+              latestApi = api
+            }}
+          />
+        </PresentationProvider>
+      )
+
+      await waitFor(() => expect(screen.getByTestId('status').textContent).toBe('active'))
+
+      // Bot leaves the room.
+      mockUseRemoteParticipants.mockReturnValue([])
+      rerender(
+        <PresentationProvider>
+          <Probe
+            onReady={api => {
+              latestApi = api
+            }}
+          />
+        </PresentationProvider>
+      )
+
+      await waitFor(() => expect(screen.getByTestId('status').textContent).toBe('idle'))
+    })
+  })
+})

--- a/src/context/PresentationContext.tsx
+++ b/src/context/PresentationContext.tsx
@@ -11,7 +11,10 @@ interface PresentationState {
   slideCount: number
   currentSlide: number
   fileType: 'pdf' | 'pptx' | null
-  status: 'idle' | 'uploading' | 'active' | 'error'
+  // 'starting' covers the window between upload completion and the bot joining
+  // the room — without it, the bot-absence cleanup effect below would briefly
+  // snap state back to 'idle' on the render right after upload resolves.
+  status: 'idle' | 'uploading' | 'starting' | 'active' | 'error'
   error: string | null
   slideVideos: SlideVideoInfo[]
   videoState: 'idle' | 'loading' | 'playing' | 'paused'
@@ -81,6 +84,28 @@ function isPresentationStoppedMessage(data: unknown): data is { type: 'presentat
   return typeof data === 'object' && data !== null && (data as Record<string, unknown>).type === 'presentation:stopped'
 }
 
+// Validates participant metadata so we don't let a malformed/spoofed field
+// (e.g. `slideCount: "ten"`) flow into React state via the metadata sync path.
+function isPresentationBotMetadata(data: unknown): data is PresentationBotMetadata {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  if (d.role !== 'presentation') return false
+  if (d.id !== undefined && typeof d.id !== 'string') return false
+  if (d.slideCount !== undefined && typeof d.slideCount !== 'number') return false
+  if (d.currentSlide !== undefined && typeof d.currentSlide !== 'number') return false
+  if (d.fileType !== undefined && d.fileType !== 'pdf' && d.fileType !== 'pptx') return false
+  if (
+    d.videoState !== undefined &&
+    d.videoState !== 'idle' &&
+    d.videoState !== 'loading' &&
+    d.videoState !== 'playing' &&
+    d.videoState !== 'paused'
+  )
+    return false
+  if (d.slideVideos !== undefined && !Array.isArray(d.slideVideos)) return false
+  return true
+}
+
 const PresentationContext = createContext<PresentationContextValue | undefined>(undefined)
 
 function PresentationProvider({ children }: { children: ReactNode }) {
@@ -113,15 +138,17 @@ function PresentationProvider({ children }: { children: ReactNode }) {
     [room]
   )
 
-  // Find the presentation bot among remote participants and read its metadata
+  // Find the presentation bot among remote participants and read its metadata.
+  // Runtime-validate with `isPresentationBotMetadata` so a malformed field
+  // (e.g. `slideCount: "ten"`) can't leak into state via the metadata sync path.
   const { presentationParticipantIdentity, botMetadata } = useMemo<{
     presentationParticipantIdentity: string | null
     botMetadata: PresentationBotMetadata | null
   }>(() => {
     for (const p of remoteParticipants) {
-      const metadata = parseParticipantMetadata<PresentationBotMetadata>(p)
-      if (metadata?.role === 'presentation') {
-        return { presentationParticipantIdentity: p.identity, botMetadata: metadata }
+      const parsed = parseParticipantMetadata(p)
+      if (isPresentationBotMetadata(parsed)) {
+        return { presentationParticipantIdentity: p.identity, botMetadata: parsed }
       }
     }
     return { presentationParticipantIdentity: null, botMetadata: null }
@@ -226,12 +253,15 @@ function PresentationProvider({ children }: { children: ReactNode }) {
         const botToken = await getPresentationBotToken(streamingKey)
         const info = await upload(botToken.token, botToken.url)
 
+        // 'starting' until the bot actually joins the room. The metadata sync
+        // effect will transition to 'active' once `presentationParticipantIdentity`
+        // is populated — this avoids racing with the bot-absence cleanup effect.
         setState({
           id: info.id,
           slideCount: info.slideCount,
           currentSlide: 0,
           fileType: info.fileType,
-          status: 'active',
+          status: 'starting',
           error: null,
           slideVideos: [],
           videoState: 'idle'
@@ -322,7 +352,9 @@ function PresentationProvider({ children }: { children: ReactNode }) {
       pauseVideo,
       stopVideo,
       stopPresentation: stopPresentationHandler,
-      isPresentationActive: state.status === 'active',
+      // Treat 'starting' as active so the UI (share-menu label, icon choice)
+      // doesn't flicker back to "not presenting" during the bot-join window.
+      isPresentationActive: state.status === 'active' || state.status === 'starting',
       presentationParticipantIdentity
     }),
     [

--- a/src/context/PresentationContext.tsx
+++ b/src/context/PresentationContext.tsx
@@ -4,6 +4,7 @@ import { RoomEvent } from 'livekit-client'
 import {
   getPresentationBotToken,
   uploadPresentation,
+  uploadPresentationFromUrl,
   SlideVideoInfo
 } from '../utils/api'
 import { getStreamerToken as getStoredToken } from '../utils/localStorage'
@@ -22,6 +23,7 @@ interface PresentationState {
 interface PresentationContextValue {
   state: PresentationState
   startPresentation: (file: File) => Promise<void>
+  startPresentationFromUrl: (url: string) => Promise<void>
   navigateSlide: (action: 'next' | 'prev') => Promise<void>
   goToSlide: (index: number) => Promise<void>
   playVideo: (videoIndex: number) => Promise<void>
@@ -171,6 +173,37 @@ function PresentationProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
+  const startPresentationFromUrl = useCallback(async (url: string) => {
+    setState(prev => ({ ...prev, status: 'uploading', error: null }))
+
+    try {
+      const streamingKey = getStoredToken()
+      if (!streamingKey) {
+        throw new Error('No streaming key available')
+      }
+
+      const botToken = await getPresentationBotToken(streamingKey)
+      const info = await uploadPresentationFromUrl(url, botToken.token, botToken.url)
+
+      setState({
+        id: info.id,
+        slideCount: info.slideCount,
+        currentSlide: 0,
+        fileType: info.fileType,
+        status: 'active',
+        error: null,
+        slideVideos: [],
+        videoState: 'idle'
+      })
+    } catch (err) {
+      setState(prev => ({
+        ...prev,
+        status: 'error',
+        error: err instanceof Error ? err.message : 'Failed to start presentation from URL'
+      }))
+    }
+  }, [])
+
   const navigateSlide = useCallback(async (action: 'next' | 'prev') => {
     if (!state.id) return
     await sendCommand({ type: 'presentation:navigate', action })
@@ -210,6 +243,7 @@ function PresentationProvider({ children }: { children: ReactNode }) {
       value={{
         state,
         startPresentation,
+        startPresentationFromUrl,
         navigateSlide,
         goToSlide,
         playVideo,

--- a/src/context/PresentationContext.tsx
+++ b/src/context/PresentationContext.tsx
@@ -1,9 +1,10 @@
 import { ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useRemoteParticipants, useRoomContext } from '@livekit/components-react'
-import { RoomEvent } from 'livekit-client'
-import { getPresentationBotToken, uploadPresentation, uploadPresentationFromUrl, SlideVideoInfo } from '../utils/api'
-import { encodeCommsPacket, decodeCommsPacket } from '../utils/commsProtocol'
+import { RemoteParticipant, RoomEvent } from 'livekit-client'
+import { PresentationInfo, SlideVideoInfo, getPresentationBotToken, uploadPresentation, uploadPresentationFromUrl } from '../utils/api'
+import { decodeCommsPacket, encodeCommsPacket } from '../utils/commsProtocol'
 import { getStreamerToken as getStoredToken } from '../utils/localStorage'
+import { isPresentationBot, parseParticipantMetadata } from '../utils/participant'
 
 interface PresentationState {
   id: string | null
@@ -31,6 +32,16 @@ interface PresentationContextValue {
 }
 
 const PRESENTATION_TOPIC = 'presentation'
+
+interface PresentationBotMetadata {
+  role: 'presentation'
+  id?: string
+  slideCount?: number
+  currentSlide?: number
+  fileType?: 'pdf' | 'pptx'
+  videoState?: PresentationState['videoState']
+  slideVideos?: SlideVideoInfo[]
+}
 
 const initialState: PresentationState = {
   id: null,
@@ -60,15 +71,14 @@ function PresentationProvider({ children }: { children: ReactNode }) {
   )
 
   // Find the presentation bot among remote participants and read its metadata
-  const { presentationParticipantIdentity, botMetadata } = useMemo(() => {
+  const { presentationParticipantIdentity, botMetadata } = useMemo<{
+    presentationParticipantIdentity: string | null
+    botMetadata: PresentationBotMetadata | null
+  }>(() => {
     for (const p of remoteParticipants) {
-      try {
-        const metadata = p.metadata ? JSON.parse(p.metadata) : null
-        if (metadata?.role === 'presentation') {
-          return { presentationParticipantIdentity: p.identity, botMetadata: metadata }
-        }
-      } catch {
-        // ignore parse errors
+      const metadata = parseParticipantMetadata<PresentationBotMetadata>(p)
+      if (metadata?.role === 'presentation') {
+        return { presentationParticipantIdentity: p.identity, botMetadata: metadata }
       }
     }
     return { presentationParticipantIdentity: null, botMetadata: null }
@@ -80,7 +90,9 @@ function PresentationProvider({ children }: { children: ReactNode }) {
   const botCurrentSlide = botMetadata?.currentSlide ?? 0
   const botFileType = botMetadata?.fileType ?? null
   const botVideoState = botMetadata?.videoState ?? 'idle'
-  const botSlideVideos = botMetadata?.slideVideos
+  // JSON.parse re-allocates slideVideos every time metadata updates, so we stringify
+  // to get reference-stable equality for the effect deps and skip-guard below.
+  const botSlideVideosJson = useMemo(() => JSON.stringify(botMetadata?.slideVideos ?? []), [botMetadata])
 
   // When bot is discovered (e.g. late joiner) or its metadata changes, sync state
   useEffect(() => {
@@ -94,7 +106,9 @@ function PresentationProvider({ children }: { children: ReactNode }) {
           prev.id === botId &&
           prev.currentSlide === botCurrentSlide &&
           prev.slideCount === botSlideCount &&
-          prev.videoState === botVideoState
+          prev.fileType === botFileType &&
+          prev.videoState === botVideoState &&
+          JSON.stringify(prev.slideVideos) === botSlideVideosJson
         ) {
           return prev
         }
@@ -105,7 +119,7 @@ function PresentationProvider({ children }: { children: ReactNode }) {
           fileType: botFileType,
           status: 'active',
           error: null,
-          slideVideos: botSlideVideos ?? [],
+          slideVideos: JSON.parse(botSlideVideosJson),
           videoState: botVideoState
         }
       })
@@ -114,12 +128,15 @@ function PresentationProvider({ children }: { children: ReactNode }) {
 
     // Bot exists but metadata lacks id — request state via data channel
     sendCommand({ type: 'presentation:get-state' })
-  }, [botMetadata, botId, botSlideCount, botCurrentSlide, botFileType, botVideoState, botSlideVideos, sendCommand])
+  }, [botMetadata, botId, botSlideCount, botCurrentSlide, botFileType, botVideoState, botSlideVideosJson, sendCommand])
 
   // Listen for state broadcasts from the bot via data channel
   useEffect(() => {
     if (!room) return
-    const handleData = (payload: Uint8Array) => {
+    const handleData = (payload: Uint8Array, participant?: RemoteParticipant) => {
+      // Only accept presentation messages from the bot — reject any other sender to prevent spoofing.
+      if (!participant || !isPresentationBot(participant)) return
+
       const decoded = decodeCommsPacket(payload)
       if (!decoded || decoded.topic !== PRESENTATION_TOPIC) return
 
@@ -146,70 +163,50 @@ function PresentationProvider({ children }: { children: ReactNode }) {
     }
   }, [room])
 
-  const startPresentation = useCallback(async (file: File) => {
-    setState(prev => ({ ...prev, status: 'uploading', error: null }))
+  const runPresentationUpload = useCallback(
+    async (upload: (livekitToken: string, livekitUrl: string) => Promise<PresentationInfo>, errorLabel: string) => {
+      setState(prev => ({ ...prev, status: 'uploading', error: null }))
 
-    try {
-      const streamingKey = getStoredToken()
-      if (!streamingKey) {
-        throw new Error('No streaming key available')
+      try {
+        const streamingKey = getStoredToken()
+        if (!streamingKey) {
+          throw new Error('No streaming key available')
+        }
+
+        const botToken = await getPresentationBotToken(streamingKey)
+        const info = await upload(botToken.token, botToken.url)
+
+        setState({
+          id: info.id,
+          slideCount: info.slideCount,
+          currentSlide: 0,
+          fileType: info.fileType,
+          status: 'active',
+          error: null,
+          slideVideos: [],
+          videoState: 'idle'
+        })
+      } catch (err) {
+        setState(prev => ({
+          ...prev,
+          status: 'error',
+          error: err instanceof Error ? err.message : errorLabel
+        }))
       }
+    },
+    []
+  )
 
-      // Step 1: Get bot token from Gatekeeper
-      const botToken = await getPresentationBotToken(streamingKey)
+  const startPresentation = useCallback(
+    (file: File) => runPresentationUpload((token, url) => uploadPresentation(file, token, url), 'Failed to start presentation'),
+    [runPresentationUpload]
+  )
 
-      // Step 2: Upload file to presenter server with the bot token
-      const info = await uploadPresentation(file, botToken.token, botToken.url)
-
-      setState({
-        id: info.id,
-        slideCount: info.slideCount,
-        currentSlide: 0,
-        fileType: info.fileType,
-        status: 'active',
-        error: null,
-        slideVideos: [],
-        videoState: 'idle'
-      })
-    } catch (err) {
-      setState(prev => ({
-        ...prev,
-        status: 'error',
-        error: err instanceof Error ? err.message : 'Failed to start presentation'
-      }))
-    }
-  }, [])
-
-  const startPresentationFromUrl = useCallback(async (url: string) => {
-    setState(prev => ({ ...prev, status: 'uploading', error: null }))
-
-    try {
-      const streamingKey = getStoredToken()
-      if (!streamingKey) {
-        throw new Error('No streaming key available')
-      }
-
-      const botToken = await getPresentationBotToken(streamingKey)
-      const info = await uploadPresentationFromUrl(url, botToken.token, botToken.url)
-
-      setState({
-        id: info.id,
-        slideCount: info.slideCount,
-        currentSlide: 0,
-        fileType: info.fileType,
-        status: 'active',
-        error: null,
-        slideVideos: [],
-        videoState: 'idle'
-      })
-    } catch (err) {
-      setState(prev => ({
-        ...prev,
-        status: 'error',
-        error: err instanceof Error ? err.message : 'Failed to start presentation from URL'
-      }))
-    }
-  }, [])
+  const startPresentationFromUrl = useCallback(
+    (url: string) =>
+      runPresentationUpload((token, botUrl) => uploadPresentationFromUrl(url, token, botUrl), 'Failed to start presentation from URL'),
+    [runPresentationUpload]
+  )
 
   const navigateSlide = useCallback(
     async (action: 'next' | 'prev') => {

--- a/src/context/PresentationContext.tsx
+++ b/src/context/PresentationContext.tsx
@@ -54,6 +54,33 @@ const initialState: PresentationState = {
   videoState: 'idle'
 }
 
+// Runtime type guards for data-channel payloads. `decodeCommsPacket` correctly
+// returns `data: unknown`, so narrow with these before feeding into setState —
+// a spoofed or malformed packet would otherwise write garbage into React state.
+function isPresentationStateMessage(data: unknown): data is {
+  type: 'presentation:state'
+  id: string
+  slideCount: number
+  currentSlide: number
+  fileType: 'pdf' | 'pptx'
+  slideVideos?: SlideVideoInfo[]
+  videoState?: PresentationState['videoState']
+} {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  return (
+    d.type === 'presentation:state' &&
+    typeof d.id === 'string' &&
+    typeof d.slideCount === 'number' &&
+    typeof d.currentSlide === 'number' &&
+    (d.fileType === 'pdf' || d.fileType === 'pptx')
+  )
+}
+
+function isPresentationStoppedMessage(data: unknown): data is { type: 'presentation:stopped' } {
+  return typeof data === 'object' && data !== null && (data as Record<string, unknown>).type === 'presentation:stopped'
+}
+
 const PresentationContext = createContext<PresentationContextValue | undefined>(undefined)
 
 function PresentationProvider({ children }: { children: ReactNode }) {
@@ -67,11 +94,21 @@ function PresentationProvider({ children }: { children: ReactNode }) {
   const idRef = useRef<string | null>(null)
   idRef.current = state.id
 
+  // Mutex for runPresentationUpload. Using a ref (not state) because the
+  // useCallback below has `[]` deps and would see stale state otherwise.
+  const uploadingRef = useRef(false)
+
   const sendCommand = useCallback(
     async (command: Record<string, unknown>) => {
       if (!room?.localParticipant) return
       const packet = encodeCommsPacket(PRESENTATION_TOPIC, command)
-      await room.localParticipant.publishData(packet, { reliable: true })
+      try {
+        await room.localParticipant.publishData(packet, { reliable: true })
+      } catch (err) {
+        // Swallow transport errors so fire-and-forget call sites (navigateSlide,
+        // playVideo, …) don't produce unhandled promise rejections on disconnect.
+        console.warn('[presentation] publishData failed', err)
+      }
     },
     [room]
   )
@@ -151,20 +188,18 @@ function PresentationProvider({ children }: { children: ReactNode }) {
       const decoded = decodeCommsPacket(payload)
       if (!decoded || decoded.topic !== PRESENTATION_TOPIC) return
 
-      const message = decoded.data as Record<string, unknown>
-
-      if (message.type === 'presentation:state') {
+      if (isPresentationStateMessage(decoded.data)) {
         setState({
-          id: message.id as string,
-          slideCount: message.slideCount as number,
-          currentSlide: message.currentSlide as number,
-          fileType: message.fileType as 'pdf' | 'pptx',
+          id: decoded.data.id,
+          slideCount: decoded.data.slideCount,
+          currentSlide: decoded.data.currentSlide,
+          fileType: decoded.data.fileType,
           status: 'active',
           error: null,
-          slideVideos: (message.slideVideos as SlideVideoInfo[]) || [],
-          videoState: (message.videoState as PresentationState['videoState']) || 'idle'
+          slideVideos: decoded.data.slideVideos ?? [],
+          videoState: decoded.data.videoState ?? 'idle'
         })
-      } else if (message.type === 'presentation:stopped') {
+      } else if (isPresentationStoppedMessage(decoded.data)) {
         setState(initialState)
       }
     }
@@ -176,6 +211,10 @@ function PresentationProvider({ children }: { children: ReactNode }) {
 
   const runPresentationUpload = useCallback(
     async (upload: (livekitToken: string, livekitUrl: string) => Promise<PresentationInfo>, errorLabel: string) => {
+      // Drop concurrent invocations (e.g. double-click): racing two uploads can
+      // orphan a bot when the second-resolving call overwrites the first's state.
+      if (uploadingRef.current) return
+      uploadingRef.current = true
       setState(prev => ({ ...prev, status: 'uploading', error: null }))
 
       try {
@@ -203,6 +242,8 @@ function PresentationProvider({ children }: { children: ReactNode }) {
           status: 'error',
           error: err instanceof Error ? err.message : errorLabel
         }))
+      } finally {
+        uploadingRef.current = false
       }
     },
     []
@@ -255,8 +296,11 @@ function PresentationProvider({ children }: { children: ReactNode }) {
 
   const stopPresentationHandler = useCallback(async () => {
     if (!idRef.current) return
+    // Don't reset state optimistically: the bot's `presentation:stopped`
+    // broadcast (handled above) is the single source of truth. Resetting here
+    // would strand the UI in `idle` if the command failed, and — because
+    // idRef would already be null — retries would no-op.
     await sendCommand({ type: 'presentation:stop' })
-    setState(initialState)
   }, [sendCommand])
 
   // Clean up when bot participant disappears (presentation was stopped externally)

--- a/src/context/PresentationContext.tsx
+++ b/src/context/PresentationContext.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useRemoteParticipants, useRoomContext } from '@livekit/components-react'
 import { RemoteParticipant, RoomEvent } from 'livekit-client'
 import { PresentationInfo, SlideVideoInfo, getPresentationBotToken, uploadPresentation, uploadPresentationFromUrl } from '../utils/api'
@@ -61,6 +61,12 @@ function PresentationProvider({ children }: { children: ReactNode }) {
   const remoteParticipants = useRemoteParticipants()
   const room = useRoomContext()
 
+  // Keep the active presentation id in a ref so command callbacks stay referentially
+  // stable across state changes — state replaces on every slide nav, which would
+  // otherwise re-create every callback and re-render every consumer.
+  const idRef = useRef<string | null>(null)
+  idRef.current = state.id
+
   const sendCommand = useCallback(
     async (command: Record<string, unknown>) => {
       if (!room?.localParticipant) return
@@ -94,9 +100,14 @@ function PresentationProvider({ children }: { children: ReactNode }) {
   // to get reference-stable equality for the effect deps and skip-guard below.
   const botSlideVideosJson = useMemo(() => JSON.stringify(botMetadata?.slideVideos ?? []), [botMetadata])
 
+  // Whether the bot is present in the room at all — stable across metadata
+  // object identity changes, so it can live in the effect dep array without
+  // re-firing the sync when only the object reference turned over.
+  const hasBotMetadata = botMetadata !== null
+
   // When bot is discovered (e.g. late joiner) or its metadata changes, sync state
   useEffect(() => {
-    if (!botMetadata) return
+    if (!hasBotMetadata) return
 
     if (botId) {
       setState(prev => {
@@ -128,7 +139,7 @@ function PresentationProvider({ children }: { children: ReactNode }) {
 
     // Bot exists but metadata lacks id — request state via data channel
     sendCommand({ type: 'presentation:get-state' })
-  }, [botMetadata, botId, botSlideCount, botCurrentSlide, botFileType, botVideoState, botSlideVideosJson, sendCommand])
+  }, [hasBotMetadata, botId, botSlideCount, botCurrentSlide, botFileType, botVideoState, botSlideVideosJson, sendCommand])
 
   // Listen for state broadcasts from the bot via data channel
   useEffect(() => {
@@ -210,43 +221,43 @@ function PresentationProvider({ children }: { children: ReactNode }) {
 
   const navigateSlide = useCallback(
     async (action: 'next' | 'prev') => {
-      if (!state.id) return
+      if (!idRef.current) return
       await sendCommand({ type: 'presentation:navigate', action })
     },
-    [state.id, sendCommand]
+    [sendCommand]
   )
 
   const goToSlide = useCallback(
     async (index: number) => {
-      if (!state.id) return
+      if (!idRef.current) return
       await sendCommand({ type: 'presentation:navigate', action: 'goto', slideIndex: index })
     },
-    [state.id, sendCommand]
+    [sendCommand]
   )
 
   const playVideo = useCallback(
     async (videoIndex: number) => {
-      if (!state.id) return
+      if (!idRef.current) return
       await sendCommand({ type: 'presentation:video:play', videoIndex })
     },
-    [state.id, sendCommand]
+    [sendCommand]
   )
 
   const pauseVideo = useCallback(async () => {
-    if (!state.id) return
+    if (!idRef.current) return
     await sendCommand({ type: 'presentation:video:pause' })
-  }, [state.id, sendCommand])
+  }, [sendCommand])
 
   const stopVideo = useCallback(async () => {
-    if (!state.id) return
+    if (!idRef.current) return
     await sendCommand({ type: 'presentation:video:stop' })
-  }, [state.id, sendCommand])
+  }, [sendCommand])
 
   const stopPresentationHandler = useCallback(async () => {
-    if (!state.id) return
+    if (!idRef.current) return
     await sendCommand({ type: 'presentation:stop' })
     setState(initialState)
-  }, [state.id, sendCommand])
+  }, [sendCommand])
 
   // Clean up when bot participant disappears (presentation was stopped externally)
   useEffect(() => {
@@ -256,25 +267,35 @@ function PresentationProvider({ children }: { children: ReactNode }) {
     }
   }, [presentationParticipantIdentity, state.status])
 
-  return (
-    <PresentationContext.Provider
-      value={{
-        state,
-        startPresentation,
-        startPresentationFromUrl,
-        navigateSlide,
-        goToSlide,
-        playVideo,
-        pauseVideo,
-        stopVideo,
-        stopPresentation: stopPresentationHandler,
-        isPresentationActive: state.status === 'active',
-        presentationParticipantIdentity
-      }}
-    >
-      {children}
-    </PresentationContext.Provider>
+  const value = useMemo<PresentationContextValue>(
+    () => ({
+      state,
+      startPresentation,
+      startPresentationFromUrl,
+      navigateSlide,
+      goToSlide,
+      playVideo,
+      pauseVideo,
+      stopVideo,
+      stopPresentation: stopPresentationHandler,
+      isPresentationActive: state.status === 'active',
+      presentationParticipantIdentity
+    }),
+    [
+      state,
+      startPresentation,
+      startPresentationFromUrl,
+      navigateSlide,
+      goToSlide,
+      playVideo,
+      pauseVideo,
+      stopVideo,
+      stopPresentationHandler,
+      presentationParticipantIdentity
+    ]
   )
+
+  return <PresentationContext.Provider value={value}>{children}</PresentationContext.Provider>
 }
 
 function usePresentation() {

--- a/src/context/PresentationContext.tsx
+++ b/src/context/PresentationContext.tsx
@@ -1,12 +1,7 @@
 import { ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useRemoteParticipants, useRoomContext } from '@livekit/components-react'
 import { RoomEvent } from 'livekit-client'
-import {
-  getPresentationBotToken,
-  uploadPresentation,
-  uploadPresentationFromUrl,
-  SlideVideoInfo
-} from '../utils/api'
+import { getPresentationBotToken, uploadPresentation, uploadPresentationFromUrl, SlideVideoInfo } from '../utils/api'
 import { encodeCommsPacket, decodeCommsPacket } from '../utils/commsProtocol'
 import { getStreamerToken as getStoredToken } from '../utils/localStorage'
 
@@ -55,11 +50,14 @@ function PresentationProvider({ children }: { children: ReactNode }) {
   const remoteParticipants = useRemoteParticipants()
   const room = useRoomContext()
 
-  const sendCommand = useCallback(async (command: Record<string, unknown>) => {
-    if (!room?.localParticipant) return
-    const packet = encodeCommsPacket(PRESENTATION_TOPIC, command)
-    await room.localParticipant.publishData(packet, { reliable: true })
-  }, [room])
+  const sendCommand = useCallback(
+    async (command: Record<string, unknown>) => {
+      if (!room?.localParticipant) return
+      const packet = encodeCommsPacket(PRESENTATION_TOPIC, command)
+      await room.localParticipant.publishData(packet, { reliable: true })
+    },
+    [room]
+  )
 
   // Find the presentation bot among remote participants and read its metadata
   const { presentationParticipantIdentity, botMetadata } = useMemo(() => {
@@ -91,11 +89,13 @@ function PresentationProvider({ children }: { children: ReactNode }) {
     if (botId) {
       setState(prev => {
         // Skip update if nothing meaningful changed
-        if (prev.status === 'active' &&
-            prev.id === botId &&
-            prev.currentSlide === botCurrentSlide &&
-            prev.slideCount === botSlideCount &&
-            prev.videoState === botVideoState) {
+        if (
+          prev.status === 'active' &&
+          prev.id === botId &&
+          prev.currentSlide === botCurrentSlide &&
+          prev.slideCount === botSlideCount &&
+          prev.videoState === botVideoState
+        ) {
           return prev
         }
         return {
@@ -141,7 +141,9 @@ function PresentationProvider({ children }: { children: ReactNode }) {
       }
     }
     room.on(RoomEvent.DataReceived, handleData)
-    return () => { room.off(RoomEvent.DataReceived, handleData) }
+    return () => {
+      room.off(RoomEvent.DataReceived, handleData)
+    }
   }, [room])
 
   const startPresentation = useCallback(async (file: File) => {
@@ -209,20 +211,29 @@ function PresentationProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
-  const navigateSlide = useCallback(async (action: 'next' | 'prev') => {
-    if (!state.id) return
-    await sendCommand({ type: 'presentation:navigate', action })
-  }, [state.id, sendCommand])
+  const navigateSlide = useCallback(
+    async (action: 'next' | 'prev') => {
+      if (!state.id) return
+      await sendCommand({ type: 'presentation:navigate', action })
+    },
+    [state.id, sendCommand]
+  )
 
-  const goToSlide = useCallback(async (index: number) => {
-    if (!state.id) return
-    await sendCommand({ type: 'presentation:navigate', action: 'goto', slideIndex: index })
-  }, [state.id, sendCommand])
+  const goToSlide = useCallback(
+    async (index: number) => {
+      if (!state.id) return
+      await sendCommand({ type: 'presentation:navigate', action: 'goto', slideIndex: index })
+    },
+    [state.id, sendCommand]
+  )
 
-  const playVideo = useCallback(async (videoIndex: number) => {
-    if (!state.id) return
-    await sendCommand({ type: 'presentation:video:play', videoIndex })
-  }, [state.id, sendCommand])
+  const playVideo = useCallback(
+    async (videoIndex: number) => {
+      if (!state.id) return
+      await sendCommand({ type: 'presentation:video:play', videoIndex })
+    },
+    [state.id, sendCommand]
+  )
 
   const pauseVideo = useCallback(async () => {
     if (!state.id) return

--- a/src/context/PresentationContext.tsx
+++ b/src/context/PresentationContext.tsx
@@ -1,0 +1,240 @@
+import { ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useRemoteParticipants, useRoomContext } from '@livekit/components-react'
+import { RoomEvent } from 'livekit-client'
+import {
+  getPresentationBotToken,
+  uploadPresentation,
+  SlideVideoInfo
+} from '../utils/api'
+import { getStreamerToken as getStoredToken } from '../utils/localStorage'
+
+interface PresentationState {
+  id: string | null
+  slideCount: number
+  currentSlide: number
+  fileType: 'pdf' | 'pptx' | null
+  status: 'idle' | 'uploading' | 'active' | 'error'
+  error: string | null
+  slideVideos: SlideVideoInfo[]
+  videoState: 'idle' | 'loading' | 'playing' | 'paused'
+}
+
+interface PresentationContextValue {
+  state: PresentationState
+  startPresentation: (file: File) => Promise<void>
+  navigateSlide: (action: 'next' | 'prev') => Promise<void>
+  goToSlide: (index: number) => Promise<void>
+  playVideo: (videoIndex: number) => Promise<void>
+  pauseVideo: () => Promise<void>
+  stopPresentation: () => Promise<void>
+  isPresentationActive: boolean
+  presentationParticipantIdentity: string | null
+}
+
+const initialState: PresentationState = {
+  id: null,
+  slideCount: 0,
+  currentSlide: 0,
+  fileType: null,
+  status: 'idle',
+  error: null,
+  slideVideos: [],
+  videoState: 'idle'
+}
+
+const PresentationContext = createContext<PresentationContextValue | undefined>(undefined)
+
+function PresentationProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<PresentationState>(initialState)
+  const remoteParticipants = useRemoteParticipants()
+  const room = useRoomContext()
+
+  const sendCommand = useCallback(async (command: Record<string, unknown>) => {
+    if (!room?.localParticipant) return
+    const data = new TextEncoder().encode(JSON.stringify(command))
+    await room.localParticipant.publishData(data, { reliable: true, topic: 'presentation' })
+  }, [room])
+
+  // Find the presentation bot among remote participants and read its metadata
+  const { presentationParticipantIdentity, botMetadata } = useMemo(() => {
+    for (const p of remoteParticipants) {
+      try {
+        const metadata = p.metadata ? JSON.parse(p.metadata) : null
+        if (metadata?.role === 'presentation') {
+          return { presentationParticipantIdentity: p.identity, botMetadata: metadata }
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+    return { presentationParticipantIdentity: null, botMetadata: null }
+  }, [remoteParticipants])
+
+  // Extract primitive fields for stable effect dependencies (rerender-dependencies)
+  const botId = botMetadata?.id ?? null
+  const botSlideCount = botMetadata?.slideCount ?? 0
+  const botCurrentSlide = botMetadata?.currentSlide ?? 0
+  const botFileType = botMetadata?.fileType ?? null
+  const botVideoState = botMetadata?.videoState ?? 'idle'
+  const botSlideVideos = botMetadata?.slideVideos
+
+  // When bot is discovered (e.g. late joiner) or its metadata changes, sync state
+  useEffect(() => {
+    if (!botMetadata) return
+
+    if (botId) {
+      setState(prev => {
+        // Skip update if nothing meaningful changed
+        if (prev.status === 'active' &&
+            prev.id === botId &&
+            prev.currentSlide === botCurrentSlide &&
+            prev.slideCount === botSlideCount &&
+            prev.videoState === botVideoState) {
+          return prev
+        }
+        return {
+          id: botId,
+          slideCount: botSlideCount,
+          currentSlide: botCurrentSlide,
+          fileType: botFileType,
+          status: 'active',
+          error: null,
+          slideVideos: botSlideVideos ?? [],
+          videoState: botVideoState
+        }
+      })
+      return
+    }
+
+    // Bot exists but metadata lacks id — request state via data channel
+    sendCommand({ type: 'presentation:get-state' })
+  }, [botMetadata, botId, botSlideCount, botCurrentSlide, botFileType, botVideoState, botSlideVideos, sendCommand])
+
+  // Listen for state broadcasts from the bot via data channel
+  useEffect(() => {
+    if (!room) return
+    const handleData = (payload: Uint8Array, _participant?: any, _kind?: any, topic?: string) => {
+      if (topic !== 'presentation') return
+      try {
+        const message = JSON.parse(new TextDecoder().decode(payload))
+        if (message.type === 'presentation:state') {
+          setState({
+            id: message.id,
+            slideCount: message.slideCount,
+            currentSlide: message.currentSlide,
+            fileType: message.fileType,
+            status: 'active',
+            error: null,
+            slideVideos: message.slideVideos || [],
+            videoState: message.videoState || 'idle'
+          })
+        } else if (message.type === 'presentation:stopped') {
+          setState(initialState)
+        }
+      } catch { /* ignore malformed messages */ }
+    }
+    room.on(RoomEvent.DataReceived, handleData)
+    return () => { room.off(RoomEvent.DataReceived, handleData) }
+  }, [room])
+
+  const startPresentation = useCallback(async (file: File) => {
+    setState(prev => ({ ...prev, status: 'uploading', error: null }))
+
+    try {
+      const streamingKey = getStoredToken()
+      if (!streamingKey) {
+        throw new Error('No streaming key available')
+      }
+
+      // Step 1: Get bot token from Gatekeeper
+      const botToken = await getPresentationBotToken(streamingKey)
+
+      // Step 2: Upload file to presenter server with the bot token
+      const info = await uploadPresentation(file, botToken.token, botToken.url)
+
+      setState({
+        id: info.id,
+        slideCount: info.slideCount,
+        currentSlide: 0,
+        fileType: info.fileType,
+        status: 'active',
+        error: null,
+        slideVideos: [],
+        videoState: 'idle'
+      })
+    } catch (err) {
+      setState(prev => ({
+        ...prev,
+        status: 'error',
+        error: err instanceof Error ? err.message : 'Failed to start presentation'
+      }))
+    }
+  }, [])
+
+  const navigateSlide = useCallback(async (action: 'next' | 'prev') => {
+    if (!state.id) return
+    await sendCommand({ type: 'presentation:navigate', action })
+  }, [state.id, sendCommand])
+
+  const goToSlide = useCallback(async (index: number) => {
+    if (!state.id) return
+    await sendCommand({ type: 'presentation:navigate', action: 'goto', slideIndex: index })
+  }, [state.id, sendCommand])
+
+  const playVideo = useCallback(async (videoIndex: number) => {
+    if (!state.id) return
+    await sendCommand({ type: 'presentation:video:play', videoIndex })
+  }, [state.id, sendCommand])
+
+  const pauseVideo = useCallback(async () => {
+    if (!state.id) return
+    await sendCommand({ type: 'presentation:video:pause' })
+  }, [state.id, sendCommand])
+
+  const stopPresentationHandler = useCallback(async () => {
+    if (!state.id) return
+    await sendCommand({ type: 'presentation:stop' })
+    setState(initialState)
+  }, [state.id, sendCommand])
+
+  // Clean up when bot participant disappears (presentation was stopped externally)
+  useEffect(() => {
+    if (state.status === 'active' && !presentationParticipantIdentity) {
+      // Bot left the room — presentation ended
+      setState(initialState)
+    }
+  }, [presentationParticipantIdentity, state.status])
+
+  return (
+    <PresentationContext.Provider
+      value={{
+        state,
+        startPresentation,
+        navigateSlide,
+        goToSlide,
+        playVideo,
+        pauseVideo,
+        stopPresentation: stopPresentationHandler,
+        isPresentationActive: state.status === 'active',
+        presentationParticipantIdentity
+      }}
+    >
+      {children}
+    </PresentationContext.Provider>
+  )
+}
+
+function usePresentation() {
+  const context = useContext(PresentationContext)
+  if (!context) {
+    throw new Error('usePresentation must be used within PresentationProvider')
+  }
+  return context
+}
+
+function usePresentationOptional() {
+  return useContext(PresentationContext) ?? null
+}
+
+export { PresentationProvider, usePresentation, usePresentationOptional }
+export type { PresentationState, PresentationContextValue }

--- a/src/context/PresentationContext.tsx
+++ b/src/context/PresentationContext.tsx
@@ -7,6 +7,7 @@ import {
   uploadPresentationFromUrl,
   SlideVideoInfo
 } from '../utils/api'
+import { encodeCommsPacket, decodeCommsPacket } from '../utils/commsProtocol'
 import { getStreamerToken as getStoredToken } from '../utils/localStorage'
 
 interface PresentationState {
@@ -33,6 +34,8 @@ interface PresentationContextValue {
   presentationParticipantIdentity: string | null
 }
 
+const PRESENTATION_TOPIC = 'presentation'
+
 const initialState: PresentationState = {
   id: null,
   slideCount: 0,
@@ -53,8 +56,8 @@ function PresentationProvider({ children }: { children: ReactNode }) {
 
   const sendCommand = useCallback(async (command: Record<string, unknown>) => {
     if (!room?.localParticipant) return
-    const data = new TextEncoder().encode(JSON.stringify(command))
-    await room.localParticipant.publishData(data, { reliable: true, topic: 'presentation' })
+    const packet = encodeCommsPacket(PRESENTATION_TOPIC, command)
+    await room.localParticipant.publishData(packet, { reliable: true })
   }, [room])
 
   // Find the presentation bot among remote participants and read its metadata
@@ -115,25 +118,26 @@ function PresentationProvider({ children }: { children: ReactNode }) {
   // Listen for state broadcasts from the bot via data channel
   useEffect(() => {
     if (!room) return
-    const handleData = (payload: Uint8Array, _participant?: any, _kind?: any, topic?: string) => {
-      if (topic !== 'presentation') return
-      try {
-        const message = JSON.parse(new TextDecoder().decode(payload))
-        if (message.type === 'presentation:state') {
-          setState({
-            id: message.id,
-            slideCount: message.slideCount,
-            currentSlide: message.currentSlide,
-            fileType: message.fileType,
-            status: 'active',
-            error: null,
-            slideVideos: message.slideVideos || [],
-            videoState: message.videoState || 'idle'
-          })
-        } else if (message.type === 'presentation:stopped') {
-          setState(initialState)
-        }
-      } catch { /* ignore malformed messages */ }
+    const handleData = (payload: Uint8Array) => {
+      const decoded = decodeCommsPacket(payload)
+      if (!decoded || decoded.topic !== PRESENTATION_TOPIC) return
+
+      const message = decoded.data as Record<string, unknown>
+
+      if (message.type === 'presentation:state') {
+        setState({
+          id: message.id as string,
+          slideCount: message.slideCount as number,
+          currentSlide: message.currentSlide as number,
+          fileType: message.fileType as 'pdf' | 'pptx',
+          status: 'active',
+          error: null,
+          slideVideos: (message.slideVideos as SlideVideoInfo[]) || [],
+          videoState: (message.videoState as PresentationState['videoState']) || 'idle'
+        })
+      } else if (message.type === 'presentation:stopped') {
+        setState(initialState)
+      }
     }
     room.on(RoomEvent.DataReceived, handleData)
     return () => { room.off(RoomEvent.DataReceived, handleData) }

--- a/src/context/PresentationContext.tsx
+++ b/src/context/PresentationContext.tsx
@@ -29,6 +29,7 @@ interface PresentationContextValue {
   goToSlide: (index: number) => Promise<void>
   playVideo: (videoIndex: number) => Promise<void>
   pauseVideo: () => Promise<void>
+  stopVideo: () => Promise<void>
   stopPresentation: () => Promise<void>
   isPresentationActive: boolean
   presentationParticipantIdentity: string | null
@@ -228,6 +229,11 @@ function PresentationProvider({ children }: { children: ReactNode }) {
     await sendCommand({ type: 'presentation:video:pause' })
   }, [state.id, sendCommand])
 
+  const stopVideo = useCallback(async () => {
+    if (!state.id) return
+    await sendCommand({ type: 'presentation:video:stop' })
+  }, [state.id, sendCommand])
+
   const stopPresentationHandler = useCallback(async () => {
     if (!state.id) return
     await sendCommand({ type: 'presentation:stop' })
@@ -252,6 +258,7 @@ function PresentationProvider({ children }: { children: ReactNode }) {
         goToSlide,
         playVideo,
         pauseVideo,
+        stopVideo,
         stopPresentation: stopPresentationHandler,
         isPresentationActive: state.status === 'active',
         presentationParticipantIdentity

--- a/src/context/PresentationContext.tsx
+++ b/src/context/PresentationContext.tsx
@@ -30,6 +30,7 @@ interface PresentationContextValue {
   pauseVideo: () => Promise<void>
   stopVideo: () => Promise<void>
   stopPresentation: () => Promise<void>
+  dismissError: () => void
   isPresentationActive: boolean
   presentationParticipantIdentity: string | null
 }
@@ -333,6 +334,12 @@ function PresentationProvider({ children }: { children: ReactNode }) {
     await sendCommand({ type: 'presentation:stop' })
   }, [sendCommand])
 
+  // Dismiss the error overlay and return the state machine to `idle` so the
+  // user can try starting a presentation again.
+  const dismissError = useCallback(() => {
+    setState(prev => (prev.status === 'error' ? initialState : prev))
+  }, [])
+
   // Clean up when bot participant disappears (presentation was stopped externally)
   useEffect(() => {
     if (state.status === 'active' && !presentationParticipantIdentity) {
@@ -352,6 +359,7 @@ function PresentationProvider({ children }: { children: ReactNode }) {
       pauseVideo,
       stopVideo,
       stopPresentation: stopPresentationHandler,
+      dismissError,
       // Treat 'starting' as active so the UI (share-menu label, icon choice)
       // doesn't flicker back to "not presenting" during the bot-join window.
       isPresentationActive: state.status === 'active' || state.status === 'starting',
@@ -367,6 +375,7 @@ function PresentationProvider({ children }: { children: ReactNode }) {
       pauseVideo,
       stopVideo,
       stopPresentationHandler,
+      dismissError,
       presentationParticipantIdentity
     ]
   )

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -23,7 +23,9 @@ function useChat() {
     const messages: ReceivedChatMessage[] = []
 
     // Listen for data messages
-    const handleDataReceived = (payload: Uint8Array, participant?: Participant) => {
+    const handleDataReceived = (payload: Uint8Array, participant?: Participant, _kind?: any, topic?: string) => {
+      // Skip messages with a topic — those are handled by their own listeners (e.g. presentation)
+      if (topic) return
       try {
         // Decode Decentraland protocol message (protobuf)
         const packet = Packet.decode(payload)

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -23,9 +23,7 @@ function useChat() {
     const messages: ReceivedChatMessage[] = []
 
     // Listen for data messages
-    const handleDataReceived = (payload: Uint8Array, participant?: Participant, _kind?: any, topic?: string) => {
-      // Skip messages with a topic — those are handled by their own listeners (e.g. presentation)
-      if (topic) return
+    const handleDataReceived = (payload: Uint8Array, participant?: Participant) => {
       try {
         // Decode Decentraland protocol message (protobuf)
         const packet = Packet.decode(payload)

--- a/src/modules/translation/locales/en.json
+++ b/src/modules/translation/locales/en.json
@@ -59,7 +59,9 @@
     "url_invalid": "Please enter a valid URL",
     "url_https_required": "URL must use https://",
     "file_too_large": "File is too large. Maximum size is {maxMb}MB.",
-    "file_invalid_type": "Unsupported file type. Please upload a PDF or PPTX file."
+    "file_invalid_type": "Unsupported file type. Please upload a PDF or PPTX file.",
+    "presentation_error_default": "Failed to start presentation.",
+    "dismiss_error": "Dismiss error"
   },
   "device_selector": {
     "audio_input": "Audio Input",

--- a/src/modules/translation/locales/en.json
+++ b/src/modules/translation/locales/en.json
@@ -58,7 +58,8 @@
     "presentation": "Presentation",
     "url_invalid": "Please enter a valid URL",
     "url_https_required": "URL must use https://",
-    "file_too_large": "File is too large. Maximum size is {maxMb}MB."
+    "file_too_large": "File is too large. Maximum size is {maxMb}MB.",
+    "file_invalid_type": "Unsupported file type. Please upload a PDF or PPTX file."
   },
   "device_selector": {
     "audio_input": "Audio Input",

--- a/src/modules/translation/locales/en.json
+++ b/src/modules/translation/locales/en.json
@@ -45,7 +45,19 @@
     "connecting": "Connecting...",
     "connected": "Connected",
     "mute_cast": "Mute this Cast audio while you're in World",
-    "unmute_cast": "Unmute Cast audio"
+    "unmute_cast": "Unmute Cast audio",
+    "share_presentation": "Share Presentation",
+    "stop_presentation": "Stop Presentation",
+    "uploading_presentation": "Uploading presentation...",
+    "paste_presentation_url": "Paste your presentation URL",
+    "share": "Share",
+    "or": "or",
+    "browse_local_files": "Browse your local files",
+    "supported_formats": "Supported formats: PDF, PPTX.",
+    "initializing_video": "Initializing video...",
+    "presentation": "Presentation",
+    "url_invalid": "Please enter a valid URL",
+    "url_https_required": "URL must use https://"
   },
   "device_selector": {
     "audio_input": "Audio Input",

--- a/src/modules/translation/locales/en.json
+++ b/src/modules/translation/locales/en.json
@@ -57,7 +57,8 @@
     "initializing_video": "Initializing video...",
     "presentation": "Presentation",
     "url_invalid": "Please enter a valid URL",
-    "url_https_required": "URL must use https://"
+    "url_https_required": "URL must use https://",
+    "file_too_large": "File is too large. Maximum size is {maxMb}MB."
   },
   "device_selector": {
     "audio_input": "Audio Input",

--- a/src/modules/translation/locales/en.json
+++ b/src/modules/translation/locales/en.json
@@ -43,7 +43,9 @@
     "reconnect": "Reconnect",
     "disconnected": "Disconnected",
     "connecting": "Connecting...",
-    "connected": "Connected"
+    "connected": "Connected",
+    "mute_cast": "Mute this Cast audio while you're in World",
+    "unmute_cast": "Unmute Cast audio"
   },
   "device_selector": {
     "audio_input": "Audio Input",

--- a/src/modules/translation/locales/es.json
+++ b/src/modules/translation/locales/es.json
@@ -43,7 +43,9 @@
     "reconnect": "Reconectar",
     "disconnected": "Desconectado",
     "connecting": "Conectando...",
-    "connected": "Conectado"
+    "connected": "Conectado",
+    "mute_cast": "Silenciar el audio de este Cast mientras estás en el Mundo",
+    "unmute_cast": "Activar audio del Cast"
   },
   "device_selector": {
     "audio_input": "Entrada de Audio",

--- a/src/modules/translation/locales/es.json
+++ b/src/modules/translation/locales/es.json
@@ -58,7 +58,8 @@
     "presentation": "Presentación",
     "url_invalid": "Por favor ingresa una URL válida",
     "url_https_required": "La URL debe usar https://",
-    "file_too_large": "El archivo es demasiado grande. Tamaño máximo {maxMb}MB."
+    "file_too_large": "El archivo es demasiado grande. Tamaño máximo {maxMb}MB.",
+    "file_invalid_type": "Tipo de archivo no compatible. Sube un archivo PDF o PPTX."
   },
   "device_selector": {
     "audio_input": "Entrada de Audio",

--- a/src/modules/translation/locales/es.json
+++ b/src/modules/translation/locales/es.json
@@ -45,7 +45,19 @@
     "connecting": "Conectando...",
     "connected": "Conectado",
     "mute_cast": "Silenciar el audio de este Cast mientras estás en el Mundo",
-    "unmute_cast": "Activar audio del Cast"
+    "unmute_cast": "Activar audio del Cast",
+    "share_presentation": "Compartir Presentación",
+    "stop_presentation": "Detener Presentación",
+    "uploading_presentation": "Subiendo presentación...",
+    "paste_presentation_url": "Pega la URL de tu presentación",
+    "share": "Compartir",
+    "or": "o",
+    "browse_local_files": "Busca en tus archivos locales",
+    "supported_formats": "Formatos admitidos: PDF, PPTX.",
+    "initializing_video": "Inicializando video...",
+    "presentation": "Presentación",
+    "url_invalid": "Por favor ingresa una URL válida",
+    "url_https_required": "La URL debe usar https://"
   },
   "device_selector": {
     "audio_input": "Entrada de Audio",

--- a/src/modules/translation/locales/es.json
+++ b/src/modules/translation/locales/es.json
@@ -57,7 +57,8 @@
     "initializing_video": "Inicializando video...",
     "presentation": "Presentación",
     "url_invalid": "Por favor ingresa una URL válida",
-    "url_https_required": "La URL debe usar https://"
+    "url_https_required": "La URL debe usar https://",
+    "file_too_large": "El archivo es demasiado grande. Tamaño máximo {maxMb}MB."
   },
   "device_selector": {
     "audio_input": "Entrada de Audio",

--- a/src/modules/translation/locales/es.json
+++ b/src/modules/translation/locales/es.json
@@ -59,7 +59,9 @@
     "url_invalid": "Por favor ingresa una URL válida",
     "url_https_required": "La URL debe usar https://",
     "file_too_large": "El archivo es demasiado grande. Tamaño máximo {maxMb}MB.",
-    "file_invalid_type": "Tipo de archivo no compatible. Sube un archivo PDF o PPTX."
+    "file_invalid_type": "Tipo de archivo no compatible. Sube un archivo PDF o PPTX.",
+    "presentation_error_default": "No se pudo iniciar la presentación.",
+    "dismiss_error": "Descartar error"
   },
   "device_selector": {
     "audio_input": "Entrada de Audio",

--- a/src/modules/translation/locales/zh.json
+++ b/src/modules/translation/locales/zh.json
@@ -57,7 +57,8 @@
     "initializing_video": "正在初始化视频...",
     "presentation": "演示文稿",
     "url_invalid": "请输入有效的URL",
-    "url_https_required": "URL必须使用https://"
+    "url_https_required": "URL必须使用https://",
+    "file_too_large": "文件过大。最大大小为{maxMb}MB。"
   },
   "device_selector": {
     "audio_input": "音频输入",

--- a/src/modules/translation/locales/zh.json
+++ b/src/modules/translation/locales/zh.json
@@ -43,7 +43,9 @@
     "reconnect": "重新连接",
     "disconnected": "已断开",
     "connecting": "连接中...",
-    "connected": "已连接"
+    "connected": "已连接",
+    "mute_cast": "在世界中时静音此Cast音频",
+    "unmute_cast": "取消静音Cast音频"
   },
   "device_selector": {
     "audio_input": "音频输入",

--- a/src/modules/translation/locales/zh.json
+++ b/src/modules/translation/locales/zh.json
@@ -59,7 +59,9 @@
     "url_invalid": "请输入有效的URL",
     "url_https_required": "URL必须使用https://",
     "file_too_large": "文件过大。最大大小为{maxMb}MB。",
-    "file_invalid_type": "不支持的文件类型。请上传 PDF 或 PPTX 文件。"
+    "file_invalid_type": "不支持的文件类型。请上传 PDF 或 PPTX 文件。",
+    "presentation_error_default": "无法启动演示文稿。",
+    "dismiss_error": "关闭错误"
   },
   "device_selector": {
     "audio_input": "音频输入",

--- a/src/modules/translation/locales/zh.json
+++ b/src/modules/translation/locales/zh.json
@@ -58,7 +58,8 @@
     "presentation": "演示文稿",
     "url_invalid": "请输入有效的URL",
     "url_https_required": "URL必须使用https://",
-    "file_too_large": "文件过大。最大大小为{maxMb}MB。"
+    "file_too_large": "文件过大。最大大小为{maxMb}MB。",
+    "file_invalid_type": "不支持的文件类型。请上传 PDF 或 PPTX 文件。"
   },
   "device_selector": {
     "audio_input": "音频输入",

--- a/src/modules/translation/locales/zh.json
+++ b/src/modules/translation/locales/zh.json
@@ -45,7 +45,19 @@
     "connecting": "连接中...",
     "connected": "已连接",
     "mute_cast": "在世界中时静音此Cast音频",
-    "unmute_cast": "取消静音Cast音频"
+    "unmute_cast": "取消静音Cast音频",
+    "share_presentation": "共享演示文稿",
+    "stop_presentation": "停止演示",
+    "uploading_presentation": "正在上传演示文稿...",
+    "paste_presentation_url": "粘贴您的演示文稿URL",
+    "share": "共享",
+    "or": "或",
+    "browse_local_files": "浏览本地文件",
+    "supported_formats": "支持的格式：PDF, PPTX。",
+    "initializing_video": "正在初始化视频...",
+    "presentation": "演示文稿",
+    "url_invalid": "请输入有效的URL",
+    "url_https_required": "URL必须使用https://"
   },
   "device_selector": {
     "audio_input": "音频输入",

--- a/src/tests/setupTests.ts
+++ b/src/tests/setupTests.ts
@@ -1,4 +1,13 @@
 import '@testing-library/jest-dom'
+import { TextDecoder, TextEncoder } from 'util'
+
+// jsdom doesn't expose TextEncoder/TextDecoder on globalThis — polyfill from Node's util.
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder as unknown as typeof globalThis.TextEncoder
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+  globalThis.TextDecoder = TextDecoder as unknown as typeof globalThis.TextDecoder
+}
 
 // Mock window.matchMedia
 Object.defineProperty(window, 'matchMedia', {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -146,15 +146,6 @@ interface SlideVideoInfo {
   geometry: { x: number; y: number; width: number; height: number }
 }
 
-interface PresentationState {
-  id: string
-  slideCount: number
-  currentSlide: number
-  fileType: 'pdf' | 'pptx'
-  slideVideos: SlideVideoInfo[]
-  videoState: 'idle' | 'playing' | 'paused'
-}
-
 async function getPresentationBotToken(streamingKey: string): Promise<PresentationBotTokenResponse> {
   const baseUrl = config.get('GATEKEEPER_URL')
   const response = await fetch(`${baseUrl}/cast/presentation-bot-token`, {
@@ -170,11 +161,7 @@ async function getPresentationBotToken(streamingKey: string): Promise<Presentati
   return response.json()
 }
 
-async function uploadPresentation(
-  file: File,
-  livekitToken: string,
-  livekitUrl: string
-): Promise<PresentationInfo> {
+async function uploadPresentation(file: File, livekitToken: string, livekitUrl: string): Promise<PresentationInfo> {
   const presenterUrl = config.get('PRESENTER_SERVER_URL')
   const formData = new FormData()
   formData.append('file', file)
@@ -193,76 +180,7 @@ async function uploadPresentation(
   return response.json()
 }
 
-async function navigatePresentation(
-  id: string,
-  action: 'next' | 'prev' | 'goto',
-  slideIndex?: number
-): Promise<PresentationState> {
-  const presenterUrl = config.get('PRESENTER_SERVER_URL')
-  const response = await fetch(`${presenterUrl}/presentations/${id}/navigate`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ action, slideIndex })
-  })
-
-  if (!response.ok) {
-    throw new CastApiError(response.status, `Failed to navigate presentation: ${response.statusText}`)
-  }
-
-  return response.json()
-}
-
-async function getPresentationState(id: string): Promise<PresentationState> {
-  const presenterUrl = config.get('PRESENTER_SERVER_URL')
-  const response = await fetch(`${presenterUrl}/presentations/${id}`)
-
-  if (!response.ok) {
-    throw new CastApiError(response.status, `Failed to get presentation state: ${response.statusText}`)
-  }
-
-  return response.json()
-}
-
-async function playPresentationVideo(id: string, videoIndex: number): Promise<void> {
-  const presenterUrl = config.get('PRESENTER_SERVER_URL')
-  const response = await fetch(`${presenterUrl}/presentations/${id}/video/play`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ videoIndex })
-  })
-
-  if (!response.ok) {
-    throw new CastApiError(response.status, `Failed to play video: ${response.statusText}`)
-  }
-}
-
-async function pausePresentationVideo(id: string): Promise<void> {
-  const presenterUrl = config.get('PRESENTER_SERVER_URL')
-  const response = await fetch(`${presenterUrl}/presentations/${id}/video/pause`, {
-    method: 'POST'
-  })
-
-  if (!response.ok) {
-    throw new CastApiError(response.status, `Failed to pause video: ${response.statusText}`)
-  }
-}
-
-async function stopPresentation(id: string): Promise<void> {
-  const presenterUrl = config.get('PRESENTER_SERVER_URL')
-  const response = await fetch(`${presenterUrl}/presentations/${id}`, {
-    method: 'DELETE'
-  })
-
-  if (!response.ok) {
-    throw new CastApiError(response.status, `Failed to stop presentation: ${response.statusText}`)
-  }
-}
-
-async function uploadPresentationFromUrl(
-  url: string,
-  livekitToken: string,
-  livekitUrl: string
-): Promise<PresentationInfo> {
+async function uploadPresentationFromUrl(url: string, livekitToken: string, livekitUrl: string): Promise<PresentationInfo> {
   const presenterUrl = config.get('PRESENTER_SERVER_URL')
   const response = await fetch(`${presenterUrl}/presentations`, {
     method: 'POST',
@@ -285,11 +203,6 @@ export {
   getStreamInfo,
   getPresentationBotToken,
   uploadPresentation,
-  uploadPresentationFromUrl,
-  navigatePresentation,
-  getPresentationState,
-  playPresentationVideo,
-  pausePresentationVideo,
-  stopPresentation
+  uploadPresentationFromUrl
 }
-export type { WorldScene, WorldSceneEntity, WorldScenesResponse, PresentationInfo, PresentationState, SlideVideoInfo }
+export type { WorldScene, WorldSceneEntity, WorldScenesResponse, PresentationInfo, SlideVideoInfo }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -258,6 +258,25 @@ async function stopPresentation(id: string): Promise<void> {
   }
 }
 
+async function uploadPresentationFromUrl(
+  url: string,
+  livekitToken: string,
+  livekitUrl: string
+): Promise<PresentationInfo> {
+  const presenterUrl = config.get('PRESENTER_SERVER_URL')
+  const response = await fetch(`${presenterUrl}/presentations`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url, livekitToken, livekitUrl })
+  })
+
+  if (!response.ok) {
+    throw new CastApiError(response.status, `Failed to upload presentation from URL: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
 export {
   CastApiError,
   getStreamerToken,
@@ -266,6 +285,7 @@ export {
   getStreamInfo,
   getPresentationBotToken,
   uploadPresentation,
+  uploadPresentationFromUrl,
   navigatePresentation,
   getPresentationState,
   playPresentationVideo,

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -128,5 +128,148 @@ async function getStreamInfo(streamingKey: string): Promise<{ placeName: string;
   return response.json()
 }
 
-export { CastApiError, getStreamerToken, getWatcherToken, getWorldScenes, getStreamInfo }
-export type { WorldScene, WorldSceneEntity, WorldScenesResponse }
+interface PresentationBotTokenResponse {
+  url: string
+  token: string
+  roomId: string
+}
+
+interface PresentationInfo {
+  id: string
+  slideCount: number
+  currentSlide: number
+  fileType: 'pdf' | 'pptx'
+}
+
+interface SlideVideoInfo {
+  url: string
+  geometry: { x: number; y: number; width: number; height: number }
+}
+
+interface PresentationState {
+  id: string
+  slideCount: number
+  currentSlide: number
+  fileType: 'pdf' | 'pptx'
+  slideVideos: SlideVideoInfo[]
+  videoState: 'idle' | 'playing' | 'paused'
+}
+
+async function getPresentationBotToken(streamingKey: string): Promise<PresentationBotTokenResponse> {
+  const baseUrl = config.get('GATEKEEPER_URL')
+  const response = await fetch(`${baseUrl}/cast/presentation-bot-token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ streamingKey })
+  })
+
+  if (!response.ok) {
+    throw new CastApiError(response.status, `Failed to get presentation bot token: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+async function uploadPresentation(
+  file: File,
+  livekitToken: string,
+  livekitUrl: string
+): Promise<PresentationInfo> {
+  const presenterUrl = config.get('PRESENTER_SERVER_URL')
+  const formData = new FormData()
+  formData.append('file', file)
+  formData.append('livekitToken', livekitToken)
+  formData.append('livekitUrl', livekitUrl)
+
+  const response = await fetch(`${presenterUrl}/presentations`, {
+    method: 'POST',
+    body: formData
+  })
+
+  if (!response.ok) {
+    throw new CastApiError(response.status, `Failed to upload presentation: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+async function navigatePresentation(
+  id: string,
+  action: 'next' | 'prev' | 'goto',
+  slideIndex?: number
+): Promise<PresentationState> {
+  const presenterUrl = config.get('PRESENTER_SERVER_URL')
+  const response = await fetch(`${presenterUrl}/presentations/${id}/navigate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action, slideIndex })
+  })
+
+  if (!response.ok) {
+    throw new CastApiError(response.status, `Failed to navigate presentation: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+async function getPresentationState(id: string): Promise<PresentationState> {
+  const presenterUrl = config.get('PRESENTER_SERVER_URL')
+  const response = await fetch(`${presenterUrl}/presentations/${id}`)
+
+  if (!response.ok) {
+    throw new CastApiError(response.status, `Failed to get presentation state: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+async function playPresentationVideo(id: string, videoIndex: number): Promise<void> {
+  const presenterUrl = config.get('PRESENTER_SERVER_URL')
+  const response = await fetch(`${presenterUrl}/presentations/${id}/video/play`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ videoIndex })
+  })
+
+  if (!response.ok) {
+    throw new CastApiError(response.status, `Failed to play video: ${response.statusText}`)
+  }
+}
+
+async function pausePresentationVideo(id: string): Promise<void> {
+  const presenterUrl = config.get('PRESENTER_SERVER_URL')
+  const response = await fetch(`${presenterUrl}/presentations/${id}/video/pause`, {
+    method: 'POST'
+  })
+
+  if (!response.ok) {
+    throw new CastApiError(response.status, `Failed to pause video: ${response.statusText}`)
+  }
+}
+
+async function stopPresentation(id: string): Promise<void> {
+  const presenterUrl = config.get('PRESENTER_SERVER_URL')
+  const response = await fetch(`${presenterUrl}/presentations/${id}`, {
+    method: 'DELETE'
+  })
+
+  if (!response.ok) {
+    throw new CastApiError(response.status, `Failed to stop presentation: ${response.statusText}`)
+  }
+}
+
+export {
+  CastApiError,
+  getStreamerToken,
+  getWatcherToken,
+  getWorldScenes,
+  getStreamInfo,
+  getPresentationBotToken,
+  uploadPresentation,
+  navigatePresentation,
+  getPresentationState,
+  playPresentationVideo,
+  pausePresentationVideo,
+  stopPresentation
+}
+export type { WorldScene, WorldSceneEntity, WorldScenesResponse, PresentationInfo, PresentationState, SlideVideoInfo }

--- a/src/utils/commsProtocol.test.ts
+++ b/src/utils/commsProtocol.test.ts
@@ -1,0 +1,112 @@
+import { Packet } from '@dcl/protocol/out-js/decentraland/kernel/comms/rfc4/comms.gen'
+import { decodeCommsPacket, encodeCommsPacket } from './commsProtocol'
+
+describe('commsProtocol', () => {
+  describe('when round-tripping via encodeCommsPacket → decodeCommsPacket', () => {
+    describe('and the payload is a flat object', () => {
+      it('should return the original topic and data', () => {
+        const topic = 'presentation'
+        const data = { type: 'presentation:navigate', action: 'next' }
+
+        const encoded = encodeCommsPacket(topic, data)
+        const decoded = decodeCommsPacket(encoded)
+
+        expect(decoded).toEqual({ topic, data })
+      })
+    })
+
+    describe('and the payload is a nested object with arrays and mixed types', () => {
+      it('should preserve the full structure', () => {
+        const topic = 'presentation'
+        const data = {
+          type: 'presentation:state',
+          id: 'abc-123',
+          slideCount: 10,
+          currentSlide: 3,
+          fileType: 'pdf',
+          slideVideos: [
+            { slideIndex: 1, url: 'https://example.com/a.mp4' },
+            { slideIndex: 4, url: 'https://example.com/b.mp4' }
+          ],
+          videoState: 'playing'
+        }
+
+        const encoded = encodeCommsPacket(topic, data)
+        const decoded = decodeCommsPacket(encoded)
+
+        expect(decoded).toEqual({ topic, data })
+      })
+    })
+
+    describe('and the topic contains multi-byte UTF-8 characters', () => {
+      it('should preserve the topic exactly', () => {
+        const topic = 'présentation-🎥'
+        const data = { ok: true }
+
+        const encoded = encodeCommsPacket(topic, data)
+        const decoded = decodeCommsPacket(encoded)
+
+        expect(decoded).toEqual({ topic, data })
+      })
+    })
+
+    describe('and the data contains multi-byte UTF-8 characters', () => {
+      it('should preserve the data exactly', () => {
+        const topic = 'presentation'
+        const data = { message: 'héllo 你好 🌍' }
+
+        const encoded = encodeCommsPacket(topic, data)
+        const decoded = decodeCommsPacket(encoded)
+
+        expect(decoded).toEqual({ topic, data })
+      })
+    })
+  })
+
+  describe('when decoding a garbage (non-protobuf) payload', () => {
+    it('should return null', () => {
+      const garbage = new Uint8Array([0xff, 0xfe, 0xfd, 0xfc, 0xfb])
+
+      expect(decodeCommsPacket(garbage)).toBeNull()
+    })
+  })
+
+  describe('when decoding an empty payload', () => {
+    it('should return null', () => {
+      expect(decodeCommsPacket(new Uint8Array(0))).toBeNull()
+    })
+  })
+
+  describe('when decoding a protobuf Packet with a non-scene message', () => {
+    it('should return null', () => {
+      const packet = Packet.encode({
+        message: { $case: 'voice', voice: { encodedSamples: new Uint8Array([1, 2, 3]), index: 0, codec: 0 } }
+      }).finish()
+
+      expect(decodeCommsPacket(packet)).toBeNull()
+    })
+  })
+
+  describe('when decoding a scene packet whose first byte is not the CommsData msg type', () => {
+    it('should return null', () => {
+      const badSceneData = new Uint8Array([99, 0, 0])
+      const packet = Packet.encode({
+        message: { $case: 'scene', scene: { sceneId: '', data: badSceneData } }
+      }).finish()
+
+      expect(decodeCommsPacket(packet)).toBeNull()
+    })
+  })
+
+  describe('when decoding a CommsData packet with a truncated topic section', () => {
+    it('should return null', () => {
+      // Claim topicLen=100 but only provide 3 bytes of scene data (header only).
+      const truncated = new Uint8Array([3, 100, 0])
+      const packet = Packet.encode({
+        message: { $case: 'scene', scene: { sceneId: '', data: truncated } }
+      }).finish()
+
+      expect(decodeCommsPacket(packet)).toBeNull()
+    })
+  })
+})

--- a/src/utils/commsProtocol.ts
+++ b/src/utils/commsProtocol.ts
@@ -24,11 +24,9 @@ export function encodeCommsPacket(topic: string, data: unknown): Uint8Array {
 
 /**
  * Decodes a raw LiveKit payload into a CommsData message.
- * Returns { topic, sender, data } or null if the payload is not a valid CommsData packet.
- * Includes a raw JSON fallback for backward compatibility.
+ * Returns { topic, data } or null if the payload is not a valid CommsData packet.
  */
 export function decodeCommsPacket(payload: Uint8Array): { topic: string; data: unknown } | null {
-  // Try protobuf decode first.
   try {
     const packet = Packet.decode(payload)
     if (packet.message?.$case === 'scene') {
@@ -43,17 +41,7 @@ export function decodeCommsPacket(payload: Uint8Array): { topic: string; data: u
       }
     }
   } catch {
-    // Not a valid protobuf packet — try raw JSON fallback.
-  }
-
-  // Fallback: raw JSON for backward compatibility during migration.
-  try {
-    const data = JSON.parse(new TextDecoder().decode(payload))
-    if (typeof data?.type === 'string') {
-      return { topic: '', data }
-    }
-  } catch {
-    // Ignore malformed payloads.
+    // Not a valid protobuf packet — ignore.
   }
 
   return null

--- a/src/utils/commsProtocol.ts
+++ b/src/utils/commsProtocol.ts
@@ -1,0 +1,60 @@
+import { Packet } from '@dcl/protocol/out-js/decentraland/kernel/comms/rfc4/comms.gen'
+
+const MSG_TYPE_COMMS_DATA = 3
+
+/**
+ * Encodes a JSON-serializable message into a protobuf Packet with the CommsData wire format.
+ * Wire format inside Scene.data: [MsgType.CommsData=3][topicLen 2 bytes LE][topic UTF-8][data UTF-8].
+ */
+export function encodeCommsPacket(topic: string, data: unknown): Uint8Array {
+  const topicBytes = new TextEncoder().encode(topic)
+  const dataBytes = new TextEncoder().encode(JSON.stringify(data))
+
+  const sceneData = new Uint8Array(1 + 2 + topicBytes.length + dataBytes.length)
+  sceneData[0] = MSG_TYPE_COMMS_DATA
+  sceneData[1] = topicBytes.length & 0xff
+  sceneData[2] = (topicBytes.length >> 8) & 0xff
+  sceneData.set(topicBytes, 3)
+  sceneData.set(dataBytes, 3 + topicBytes.length)
+
+  return Packet.encode({
+    message: { $case: 'scene', scene: { sceneId: '', data: sceneData } }
+  }).finish()
+}
+
+/**
+ * Decodes a raw LiveKit payload into a CommsData message.
+ * Returns { topic, sender, data } or null if the payload is not a valid CommsData packet.
+ * Includes a raw JSON fallback for backward compatibility.
+ */
+export function decodeCommsPacket(payload: Uint8Array): { topic: string; data: unknown } | null {
+  // Try protobuf decode first.
+  try {
+    const packet = Packet.decode(payload)
+    if (packet.message?.$case === 'scene') {
+      const sd = packet.message.scene.data
+      if (sd.length > 3 && sd[0] === MSG_TYPE_COMMS_DATA) {
+        const topicLen = sd[1] | (sd[2] << 8)
+        if (sd.length >= 3 + topicLen) {
+          const topic = new TextDecoder().decode(sd.slice(3, 3 + topicLen))
+          const data = JSON.parse(new TextDecoder().decode(sd.slice(3 + topicLen)))
+          return { topic, data }
+        }
+      }
+    }
+  } catch {
+    // Not a valid protobuf packet — try raw JSON fallback.
+  }
+
+  // Fallback: raw JSON for backward compatibility during migration.
+  try {
+    const data = JSON.parse(new TextDecoder().decode(payload))
+    if (typeof data?.type === 'string') {
+      return { topic: '', data }
+    }
+  } catch {
+    // Ignore malformed payloads.
+  }
+
+  return null
+}

--- a/src/utils/commsProtocol.ts
+++ b/src/utils/commsProtocol.ts
@@ -1,12 +1,13 @@
 import { Packet } from '@dcl/protocol/out-js/decentraland/kernel/comms/rfc4/comms.gen'
 
+// Matches MsgType.CommsData in Decentraland RFC4 (dcl-protocol kernel/comms/rfc4/comms.proto)
 const MSG_TYPE_COMMS_DATA = 3
 
 /**
  * Encodes a JSON-serializable message into a protobuf Packet with the CommsData wire format.
  * Wire format inside Scene.data: [MsgType.CommsData=3][topicLen 2 bytes LE][topic UTF-8][data UTF-8].
  */
-export function encodeCommsPacket(topic: string, data: unknown): Uint8Array {
+function encodeCommsPacket(topic: string, data: unknown): Uint8Array {
   const topicBytes = new TextEncoder().encode(topic)
   const dataBytes = new TextEncoder().encode(JSON.stringify(data))
 
@@ -26,7 +27,7 @@ export function encodeCommsPacket(topic: string, data: unknown): Uint8Array {
  * Decodes a raw LiveKit payload into a CommsData message.
  * Returns { topic, data } or null if the payload is not a valid CommsData packet.
  */
-export function decodeCommsPacket(payload: Uint8Array): { topic: string; data: unknown } | null {
+function decodeCommsPacket(payload: Uint8Array): { topic: string; data: unknown } | null {
   try {
     const packet = Packet.decode(payload)
     if (packet.message?.$case === 'scene') {
@@ -46,3 +47,5 @@ export function decodeCommsPacket(payload: Uint8Array): { topic: string; data: u
 
   return null
 }
+
+export { encodeCommsPacket, decodeCommsPacket }

--- a/src/utils/participant.ts
+++ b/src/utils/participant.ts
@@ -1,0 +1,16 @@
+import type { Participant } from 'livekit-client'
+
+function parseParticipantMetadata<T = Record<string, unknown>>(participant: Pick<Participant, 'metadata'>): T | null {
+  try {
+    return participant.metadata ? (JSON.parse(participant.metadata) as T) : null
+  } catch {
+    return null
+  }
+}
+
+function isPresentationBot(participant: Pick<Participant, 'metadata'>): boolean {
+  const metadata = parseParticipantMetadata<{ role?: string }>(participant)
+  return metadata?.role === 'presentation'
+}
+
+export { parseParticipantMetadata, isPresentationBot }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,15 @@
 {
-  "routes": [
-    { "handle": "filesystem" },
-    { "src": "/(.*)", "dest": "/index.html" }
+  "version": 2,
+  "name": "cast2",
+  "build": {
+    "env": {
+      "VITE_BASE_URL": "/"
+    }
+  },
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Add presentation sharing feature to Decentraland Cast, allowing streamers to share PDF and PPTX slides via a presentation bot that joins the LiveKit room.

### Features
- **Presentation sharing**: Upload local files (PDF, PPTX) or share via URL (Google Slides, direct links)
- **Presentation controls**: Slide navigation and video playback controls for streamers
- **Mute cast audio button**: Prevents echo when users are in the Decentraland world and have the cast tab open simultaneously
- **Late-joiner sync**: New participants automatically see the current presentation state via data channel fallback

### Technical changes
- Encode/decode presentation data with protobuf `Packet` for comms protocol compatibility
- Auto-expand presentation tile in `ParticipantGrid`
- Share menu in `StreamingControls` with screen share and presentation options
- Fix toolbar dropdown z-index overlap with streamer video cards
- Configure presenter server URLs for all environments
- Vercel SPA routing fixes

### Screenshots:
#### Share Presentation:
<img width="508" height="233" alt="image" src="https://github.com/user-attachments/assets/552ee00c-2f55-42ce-96ac-dd7f15bfa7d1" />
<img width="561" height="411" alt="image" src="https://github.com/user-attachments/assets/27d04f39-e202-414f-b87a-43bb87786406" />
<img width="494" height="223" alt="image" src="https://github.com/user-attachments/assets/a8f82e60-d3ed-42bd-a290-e16481412505" />

#### Presentation Controls:
<img width="529" height="246" alt="image" src="https://github.com/user-attachments/assets/06b49066-df7b-40cf-b5da-644c2935ab3e" />
<img width="581" height="279" alt="image" src="https://github.com/user-attachments/assets/8a587123-8a39-4295-a5fb-c925ef41471b" />

